### PR TITLE
Add neuropt as optional hyperparameter search backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ app = [
 qp = [
     "cvxpy>=1.3",
 ]
+neuropt = [
+    "neuropt[llm]>=0.6",
+]
 gpu = [
     "jax[cuda12]>=0.4.20",
 ]
@@ -69,7 +72,7 @@ docs = [
     "jupyter-book>=0.15,<2",
     "sphinx-copybutton",
 ]
-all = ["jaxsr[dev,docs,cli,excel,reports,app,qp,sklearn]"]
+all = ["jaxsr[dev,docs,cli,excel,reports,app,qp,sklearn,neuropt]"]
 
 [project.scripts]
 jaxsr = "jaxsr.cli:main"

--- a/src/jaxsr/skill/guides/neuropt-integration.md
+++ b/src/jaxsr/skill/guides/neuropt-integration.md
@@ -1,0 +1,75 @@
+# neuropt Integration Guide
+
+[neuropt](https://github.com/loevlie/neuropt) is an LLM-guided hyperparameter
+optimizer. Instead of random search or Bayesian methods, it uses an LLM to read
+training results and reason about what to try next.
+
+JAXSR works with neuropt out of the box because it implements the sklearn
+estimator protocol (`get_params` / `set_params`).
+
+## Installation
+
+```bash
+pip install jaxsr[neuropt]
+# or separately:
+pip install "neuropt[llm]"
+```
+
+## Quick Start
+
+```python
+import numpy as np
+from jaxsr import BasisLibrary, SymbolicRegressor
+from neuropt import ArchSearch
+
+library = (BasisLibrary(n_features=2)
+    .add_constant()
+    .add_linear()
+    .add_polynomials(max_degree=3)
+    .add_interactions()
+)
+model = SymbolicRegressor(basis_library=library, max_terms=5)
+
+X = np.loadtxt("data.csv", delimiter=",", usecols=[0, 1])
+y = np.loadtxt("data.csv", delimiter=",", usecols=[2])
+
+def train_fn(config):
+    m = config["model"]  # neuropt injects a cloned model with the config applied
+    m.fit(X, y)
+    y_pred = np.asarray(m.predict(X))
+    mse = float(np.mean((y - y_pred) ** 2))
+    return {"score": mse}
+
+search = ArchSearch.from_model(model, train_fn, backend="claude")
+search.run(max_evals=15)
+```
+
+neuropt auto-discovers tunable parameters from `get_params()` and asks the
+LLM for reasonable search ranges. Each evaluation takes a fraction of a
+second for symbolic regression, so 15 evals is nearly instant.
+
+## Custom Search Space
+
+Override the auto-detected space with specific ranges:
+
+```python
+search = ArchSearch(
+    train_fn=train_fn,
+    search_space={
+        "max_terms": (2, 8),
+        "strategy": ["greedy_forward", "greedy_backward", "lasso_path"],
+        "information_criterion": ["aic", "aicc", "bic"],
+    },
+    backend="claude",
+)
+search.run(max_evals=15)
+```
+
+## When to Use neuropt vs GridSearchCV
+
+| | GridSearchCV | neuropt |
+|--|-------------|---------|
+| Best for | Small, discrete grids | Larger mixed spaces |
+| Search method | Exhaustive | LLM-guided |
+| Reads results | No | Yes — adapts based on scores |
+| Cost | Free | ~$0.01–0.05 per run (Claude Haiku) |

--- a/tests/test_neuropt.py
+++ b/tests/test_neuropt.py
@@ -1,0 +1,65 @@
+"""Tests for neuropt (LLM-guided hyperparameter search) integration."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+neuropt = pytest.importorskip("neuropt")
+
+from jaxsr import BasisLibrary, SymbolicRegressor
+
+
+@pytest.fixture()
+def library():
+    return BasisLibrary(n_features=2).add_constant().add_linear().add_polynomials(max_degree=2)
+
+
+@pytest.fixture()
+def X():
+    rng = np.random.RandomState(42)
+    return rng.randn(30, 2)
+
+
+@pytest.fixture()
+def y(X):
+    return 2.0 * X[:, 0] + 3.0 * X[:, 1] + 0.1 * np.random.RandomState(42).randn(30)
+
+
+class TestNeuroptIntegration:
+    """Test that neuropt.ArchSearch.from_model works with JAXSR estimators."""
+
+    def test_from_model_detects_sklearn_compat(self, library):
+        from neuropt.introspect import is_sklearn_compatible
+
+        model = SymbolicRegressor(basis_library=library)
+        assert is_sklearn_compatible(model)
+
+    def test_from_model_introspects_params(self, library):
+        from neuropt.introspect import introspect_sklearn
+
+        model = SymbolicRegressor(basis_library=library, max_terms=5)
+        info = introspect_sklearn(model)
+        assert info["model_type"] == "SymbolicRegressor"
+        assert "max_terms" in info["tunable_params"]
+        assert info["tunable_params"]["max_terms"] == 5
+
+    def test_search_runs(self, library, X, y, tmp_path):
+        model = SymbolicRegressor(basis_library=library, max_terms=3)
+
+        def train_fn(config):
+            m = config["model"]
+            m.fit(X, y)
+            y_pred = np.asarray(m.predict(X))
+            mse = float(np.mean((y - y_pred) ** 2))
+            return {"score": mse}
+
+        search = neuropt.ArchSearch.from_model(
+            model,
+            train_fn,
+            backend="none",
+            log_path=str(tmp_path / "search.jsonl"),
+        )
+        search.run(max_evals=3)
+        assert search.total_experiments == 3
+        assert search.best_score < float("inf")


### PR DESCRIPTION
## Summary

Adds [neuropt](https://github.com/loevlie/neuropt) as an optional dependency for LLM-guided hyperparameter search. Since JAXSR already implements the sklearn estimator protocol, neuropt works out of the box — this PR just documents it, tests it, and makes it installable via `pip install jaxsr[neuropt]`.

No new Python modules. Just:
- Optional dep in `pyproject.toml`
- 3 integration tests
- Usage guide

Totally understand if you'd rather not add another dependency — it's fully optional and doesn't touch any existing code.

## What neuropt does

Instead of grid search, neuropt uses an LLM to read per-fold CV scores and reason about what to try next. Usage with JAXSR:

```python
from neuropt import ArchSearch
from jaxsr import BasisLibrary, SymbolicRegressor

model = SymbolicRegressor(basis_library=library)
search = ArchSearch.from_model(model, train_fn, backend="claude")
search.run(max_evals=15)
```

## Test plan

- [x] 3 new tests pass (`test_neuropt.py`)
- [x] All 24 existing sklearn compat tests still pass
- [x] neuropt is skip-imported — tests are skipped if not installed