### PR TITLE
Implement sample_weight instead of silently ignoring it

### DIFF
--- a/.claude/skills/jaxsr/SKILL.md
+++ b/.claude/skills/jaxsr/SKILL.md
@@ -386,6 +386,12 @@ See `guides/rsm.md` for RSM designs, canonical analysis, and optimization.
 
 See `guides/active-learning.md` for acquisition functions and adaptive sampling.
 
+### "My measurements aren't equally precise"
+
+See `guides/sample-weights.md` for `sample_weight`: weighted least squares applied
+consistently through selection, information criteria, constraints and uncertainty,
+plus the effective-sample-size policy and why row duplication is not a substitute.
+
 ### "One expression isn't enough / the signal is a sum of many effects"
 
 See `guides/additive.md` for boosting-style additive symbolic regression

--- a/.claude/skills/jaxsr/guides/model-fitting.md
+++ b/.claude/skills/jaxsr/guides/model-fitting.md
@@ -266,3 +266,15 @@ y_pred = predict_fn(X_numpy)
 model.save("model.json")
 loaded = SymbolicRegressor.load("model.json")
 ```
+
+## Unequal Measurement Precision
+
+If your observations differ in precision, pass `sample_weight` to `fit()`:
+
+```python
+model.fit(X, y, sample_weight=1.0 / variances)
+```
+
+Weights are honoured by term selection, the reported MSE and information criteria,
+constraint refitting and every uncertainty method — not just the final coefficients.
+See `guides/sample-weights.md`.

--- a/.claude/skills/jaxsr/guides/sample-weights.md
+++ b/.claude/skills/jaxsr/guides/sample-weights.md
@@ -1,0 +1,134 @@
+# Sample Weights
+
+Use `sample_weight` when your observations are **not equally trustworthy**: different
+measurement precisions, replicate-derived variances, or regions of the design space that
+carry little information about the quantity you care about.
+
+```python
+model = SymbolicRegressor(basis_library=library, max_terms=4)
+model.fit(X, y, sample_weight=1.0 / variances)
+```
+
+## What weights mean
+
+Observation `i` is modelled as having variance `sigma^2 / w_i`, so the fit minimises
+
+```
+sum_i  w_i * (y_i - f(x_i))^2
+```
+
+A point with twice the weight is treated as twice as precise — equivalently, as carrying
+twice the information.
+
+**Only ratios matter.** Weights are normalised to average 1 internally, so `w`, `2*w` and
+`w/1000` give the identical model, MSE and information criteria. You never have to worry
+about what units your weights are in.
+
+## Where the weights are used
+
+Weights are not a cosmetic adjustment to the final coefficients — they run through the
+whole pipeline:
+
+| Stage | Effect |
+|-------|--------|
+| Term selection (all four strategies) | Every candidate subset is fitted and scored on the weighted objective |
+| `model.metrics_["mse"]` | Weighted MSE, `sum_i w_i r_i^2 / n` |
+| AIC / BIC / AICc | Computed from the weighted MSE (see effective sample size below) |
+| `model.metrics_["r2"]`, `model.score()` | Weighted R², about the weighted mean of `y` |
+| Term pruning (`prune_tol`) | Contributions measured on the weighted design matrix |
+| Constraint refitting | Least-squares term weighted; the constraints themselves are not |
+| `sigma_`, `covariance_matrix_`, `coefficient_intervals()` | Weighted `s^2 (Phi^T W Phi)^{-1}` |
+| `predict_interval()`, `confidence_band()` | Weighted leverages |
+| `bootstrap_coefficients()`, `bootstrap_predict()` | Residuals resampled in whitened space, refit by WLS |
+| `bootstrap_model_selection()` | Weights follow their rows into each resample |
+| `anova()` | Weighted sums of squares, about the weighted mean |
+| `cross_validate()` | Weights follow their rows into the folds |
+| `predict_conformal(method="jackknife+")` | Weighted leverages and whitened LOO residuals |
+
+## Effective sample size
+
+The `n` used by AIC/BIC/AICc stays the **nominal** number of observations. Weighting
+describes how much you trust each measurement; it does not create or destroy
+measurements.
+
+This is also why **duplicating rows is not a valid way to emulate weights** — duplication
+inflates `n`, and `k*log(n)` in BIC shifts with it, so the comparison between models
+changes for a reason that has nothing to do with the data.
+
+When most of the weight sits on a few rows, the nominal `n` overstates how much
+information the model comparison rests on. Check:
+
+```python
+model.effective_sample_size_   # Kish ESS: (sum w)^2 / sum w^2
+```
+
+For 200 points where half carry weight ~0, this returns ~100. Treat that, not `n`, as
+your intuition for how strong the evidence is.
+
+## Recipes
+
+### Known measurement variances
+
+```python
+model.fit(X, y, sample_weight=1.0 / variances)
+```
+
+### Replicate means
+
+If `y_i` is the mean of `n_i` replicates with common noise variance, its variance is
+`sigma^2 / n_i`, so the weight is the replicate count:
+
+```python
+model.fit(X_means, y_means, sample_weight=replicate_counts)
+```
+
+### A smooth taper instead of a hard threshold
+
+Rows where a derived quantity is near zero carry little information about it. Rather than
+dropping them below a cutoff — which discards partially-informative rows and puts a step
+where a taper belongs — down-weight them continuously:
+
+```python
+# information about the slope scales with |y_x|; taper smoothly near zero
+w = y_x**2 / (y_x**2 + eps**2)
+model.fit(X, y_ratio, sample_weight=w)
+```
+
+Pick `eps` on the scale of the noise in `y_x`, not as a hard "keep/drop" boundary.
+
+### Excluding a row entirely
+
+A weight of exactly `0` removes a row from the fit but keeps it in `n`. If you mean to
+drop the observation, drop it from `X` and `y` instead — that also corrects `n` and every
+criterion computed from it.
+
+## Interpreting weighted intervals
+
+For a weighted fit, `sigma_` is the noise level of a **unit-weight** observation, and
+`predict_interval()` returns the interval for a new observation of unit weight — one as
+precise as an average training point. If the new observation has a known precision
+`w_new`, scale the half-width by `1 / sqrt(w_new)`.
+
+## Validation
+
+Bad weights are rejected up front rather than silently absorbed:
+
+- wrong length → `ValueError`
+- negative entries → `ValueError`
+- `NaN` / `inf` → `ValueError`
+- all zeros → `ValueError`
+
+## Not weighted
+
+- `conformal_predict_split()` — its coverage comes from exchangeability of the
+  user-supplied calibration residuals, not from the fit. With unequal-precision
+  calibration points the interval stays valid but is uninformatively wide for the precise
+  ones. Use `method="jackknife+"` for a weight-aware interval.
+- `SymbolicClassifier` — classification weights are not implemented.
+- `max_error` in `compute_all_metrics()` — a maximum has no weighted analogue; it is
+  reported over the rows with non-zero weight.
+
+## See also
+
+- `guides/uncertainty.md` — interval methods and when to use each
+- `guides/model-fitting.md` — selection strategies and criteria

--- a/.claude/skills/jaxsr/guides/uncertainty.md
+++ b/.claude/skills/jaxsr/guides/uncertainty.md
@@ -255,3 +255,11 @@ print(f"BMA width:      {np.mean(bma_hi - bma_lo):.4f}")
 print(f"Conformal width: {np.mean(conf_hi - conf_lo):.4f}")
 print(f"Bootstrap width: {np.mean(boot['upper'] - boot['lower']):.4f}")
 ```
+
+## Weighted Fits
+
+When the model was fitted with `sample_weight`, all of the intervals above use the
+weighted covariance `s^2 (Phi^T W Phi)^{-1}` and weighted leverages, and `sigma_` is the
+noise level of a *unit-weight* observation. The one exception is split conformal
+prediction, whose calibration set is treated as unweighted. See
+`guides/sample-weights.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@ for details.
 
 ## [Unreleased]
 
+### Added
+- **`sample_weight` is now implemented** (#19). It was previously accepted by
+  `SymbolicRegressor.fit()` and silently ignored, so a user passing measurement
+  variances got an unweighted fit that looked like a weighted one. Weighted least
+  squares is now applied consistently across:
+  - all four selection strategies, so weights steer *which terms are chosen*, not
+    only their coefficients;
+  - the reported MSE, R², and the AIC/BIC/AICc computed from them;
+  - constraint refitting (`fit_constrained_ols`), term pruning, and parametric
+    parameter optimisation;
+  - `sigma_`, `covariance_matrix_`, `coefficient_intervals()`,
+    `predict_interval()`, `confidence_band()`, `anova()`, the bootstrap
+    functions, `cross_validate()`, and jackknife+ conformal prediction.
+
+  Weights are normalised to average 1, so only their ratios matter and the fit is
+  invariant to their overall scale. The effective sample size in the information
+  criteria stays the nominal `n` — weighting does not manufacture observations,
+  which is why duplicating rows is not an equivalent trick. New
+  `SymbolicRegressor.effective_sample_size_` reports the Kish effective sample
+  size as a diagnostic, and `sample_weight_` exposes the normalised weights.
+
+  Invalid weights (wrong length, negative, non-finite, all-zero) now raise
+  `ValueError` instead of being ignored.
+
+  `sample_weight` was also added to `fit_symbolic()`,
+  `MultiOutputSymbolicRegressor.fit()`, `SymbolicRegressor.score()`,
+  `fit_ols()`, `fit_ridge()`, `select_features()`, `cross_validate()`,
+  `compute_mse/rmse/mae/r2/adjusted_r2/mape/all_metrics()`, `compute_cv_score()`,
+  `compute_loo_mse()`, `compute_press()`, and `bootstrap_model_selection()`;
+  `SymbolicRegressor.update()` gained `sample_weight_new`.
+- New guide `docs/guides/sample-weights.md` (and the matching skill guide)
+  covering weight semantics, the effective-sample-size policy, recipes for
+  variance-derived and replicate weights, and what is deliberately left
+  unweighted.
+
+### Fixed
+- `compute_all_metrics()` no longer reports `max_error` over rows that carry no
+  weight.
+
 ## [0.3.0] - 2026-07-02
 
 ### Added

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -14,6 +14,7 @@ parts:
       - file: guides/cli_guide
       - file: guides/claude_code_skills
       - file: guides/performance
+      - file: guides/sample-weights
       - file: guides/sklearn-integration
 
   - caption: Examples

--- a/docs/guides/sample-weights.md
+++ b/docs/guides/sample-weights.md
@@ -1,0 +1,155 @@
+# Sample Weights
+
+Not every measurement deserves the same say in a fit. Use `sample_weight` when
+observations differ in precision — different instruments, replicate-derived variances, or
+regions of the design space that carry little information about the quantity you care
+about.
+
+```python
+import numpy as np
+from jaxsr import BasisLibrary, SymbolicRegressor
+
+X = np.random.randn(100, 2)
+y = 2.0 * X[:, 0] + 0.5 * X[:, 1] ** 2
+variances = np.repeat([0.01, 1.0], 50)  # first half measured 100x more precisely
+
+library = (
+    BasisLibrary(n_features=2, feature_names=["a", "b"])
+    .add_constant()
+    .add_linear()
+    .add_polynomials(max_degree=2)
+)
+model = SymbolicRegressor(basis_library=library, max_terms=3)
+model.fit(X, y, sample_weight=1.0 / variances)
+print(model.expression_)
+```
+
+## What a weight means
+
+Observation `i` is modelled as having variance `sigma² / wᵢ`, so the fit minimises
+
+$$\sum_i w_i \left(y_i - f(x_i)\right)^2$$
+
+A point with twice the weight is treated as twice as precise, i.e. as carrying twice the
+information.
+
+**Only ratios matter.** Weights are normalised to average 1 internally, so `w`, `2*w` and
+`w/1000` give an identical model, MSE and information criteria. The units of your weights
+are irrelevant — pass raw inverse variances without rescaling.
+
+## Weights apply everywhere, not just to the coefficients
+
+A weighted fit whose model *selection* is unweighted, or whose reported R² is unweighted,
+is worse than no weighting at all — it looks right and isn't. In JAXSR the weights run
+through the whole pipeline:
+
+| Stage | Effect of weights |
+|-------|-------------------|
+| Term selection (`greedy_forward`, `greedy_backward`, `exhaustive`, `lasso_path`) | Every candidate subset is fitted and scored on the weighted objective |
+| `model.metrics_["mse"]` | Weighted MSE, $\sum_i w_i r_i^2 / n$ |
+| AIC / BIC / AICc | Computed from the weighted MSE |
+| `model.metrics_["r2"]`, `model.score()` | Weighted R², about the weighted mean of `y` |
+| Negligible-term pruning (`prune_tol`) | Contributions measured on the weighted design matrix |
+| Constraint refitting | The least-squares term is weighted; the constraints themselves are not |
+| `sigma_`, `covariance_matrix_`, `coefficient_intervals()` | Weighted $s^2 (\Phi^\top W \Phi)^{-1}$ |
+| `predict_interval()`, `confidence_band()` | Weighted leverages |
+| `bootstrap_coefficients()`, `bootstrap_predict()` | Residuals resampled in whitened space, each replicate refit by weighted least squares |
+| `bootstrap_model_selection()` | Each weight follows its row into the resample |
+| `anova()` | Weighted sums of squares, about the weighted mean |
+| `cross_validate()` | Each weight follows its row into the folds |
+| `predict_conformal(method="jackknife+")` | Weighted leverages, whitened LOO residuals |
+| Parametric bases (`add_parametric`) | Nonlinear parameters are optimised against the weighted objective |
+
+## Effective sample size
+
+The `n` used by AIC, BIC and AICc stays the **nominal** number of observations. Weighting
+says how much you trust each measurement; it does not create or destroy measurements.
+
+This is why **duplicating rows is not a valid way to emulate weights**. Duplication
+inflates `n`, and the `k·log(n)` term in BIC moves with it, so the comparison between
+models shifts for a reason unrelated to the data.
+
+When most of the weight sits on a handful of rows, the nominal `n` overstates how much
+information a model comparison actually rests on. Check the Kish effective sample size:
+
+```python
+model.effective_sample_size_   # (Σw)² / Σw²
+```
+
+For 200 points where half carry weight ≈ 0, this returns ≈ 100. Use that number, not `n`,
+as your intuition for how strong the evidence is.
+
+## Recipes
+
+### Known measurement variances
+
+```python
+model.fit(X, y, sample_weight=1.0 / variances)
+```
+
+### Replicate means
+
+If `yᵢ` is the mean of `nᵢ` replicates sharing a noise variance, its variance is
+`sigma²/nᵢ`, so the weight is the replicate count:
+
+```python
+model.fit(X_means, y_means, sample_weight=replicate_counts)
+```
+
+### A smooth taper instead of a hard threshold
+
+Some rows carry little information about the quantity being fitted — for example when a
+derived response is a ratio whose denominator passes through zero. Dropping those rows
+below a cutoff discards partially-informative data and puts a step where a taper belongs.
+Down-weight them continuously instead:
+
+```python
+# information about the slope scales with |y_x|; taper smoothly near zero
+w = y_x**2 / (y_x**2 + eps**2)
+model.fit(X, y_ratio, sample_weight=w)
+```
+
+Choose `eps` on the scale of the noise in `y_x`, not as a keep/drop boundary.
+
+### Excluding a row
+
+A weight of exactly `0` removes a row from the fit but keeps it in `n`. If you mean to
+drop the observation, drop it from `X` and `y` instead — that also corrects `n` and every
+criterion computed from it.
+
+## Interpreting weighted intervals
+
+For a weighted fit, `sigma_` is the noise level of a **unit-weight** observation, and
+`predict_interval()` gives the interval for a new observation of unit weight — one as
+precise as an average training point. If the new observation has a known precision
+`w_new`, scale the half-width by `1/sqrt(w_new)`.
+
+```python
+model.fit(X, y, sample_weight=1.0 / variances)
+y_pred, lo, hi = model.predict_interval(X_test)   # for a unit-weight observation
+```
+
+## Validation
+
+Bad weights are rejected up front rather than silently absorbed. Each of these raises
+`ValueError`:
+
+- an array whose length differs from `len(y)`
+- negative entries
+- `NaN` or `inf`
+- all zeros
+
+## What is not weighted
+
+- **`conformal_predict_split()`** — its coverage guarantee comes from exchangeability of
+  the user-supplied calibration residuals, not from the fit. With calibration points of
+  unequal precision the interval remains valid but is uninformatively wide for the
+  precise ones. Use `method="jackknife+"` for a weight-aware interval.
+- **`SymbolicClassifier`** — weights are not implemented for classification.
+- **`max_error`** in `compute_all_metrics()` — a maximum has no weighted analogue; it is
+  reported over the rows with non-zero weight.
+
+## See also
+
+- [Uncertainty quantification example](../examples/uncertainty_quantification.ipynb)
+- [API reference](../api/index.rst)

--- a/src/jaxsr/acquisition.py
+++ b/src/jaxsr/acquisition.py
@@ -112,33 +112,51 @@ class BatchStrategy(Enum):
 # =========================================================================
 
 
+def _get_weighted_Phi_train(model: SymbolicRegressor) -> tuple[jnp.ndarray, jnp.ndarray | None]:
+    """Return the training design matrix, whitened by the fit's sample weights.
+
+    Every acquisition function below reasons about the posterior of a
+    *weighted* least-squares fit when one was requested, so the information
+    matrix must be ``Phi^T W Phi``.  Scoring a candidate against the
+    unweighted ``Phi^T Phi`` would propose the next experiment as if
+    down-weighted rows had been fully informative.
+    """
+    from .utils import whiten
+
+    weights = getattr(model, "_sample_weight", None)
+    Phi_train = model.basis_library.evaluate_subset(model._X_train, model._result.selected_indices)
+    return whiten(Phi_train, weights), weights
+
+
 def _get_pred_and_sigma(
     model: SymbolicRegressor,
     X: jnp.ndarray,
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Return (y_pred, sigma) for *X* using the OLS posterior.
 
-    sigma(x) = sigma_hat * sqrt( phi(x)^T (Phi^T Phi)^{-1} phi(x) )
+    sigma(x) = sigma_hat * sqrt( phi(x)^T (Phi^T W Phi)^{-1} phi(x) )
+
+    ``W`` is the diagonal of training sample weights (the identity for an
+    unweighted fit), and ``sigma_hat`` is the noise level of a unit-weight
+    observation.
     """
     from .uncertainty import compute_unbiased_variance
 
     X = jnp.atleast_2d(jnp.asarray(X))
     model._check_is_fitted()
 
+    weights = getattr(model, "_sample_weight", None)
     Phi_train = model.basis_library.evaluate_subset(model._X_train, model._result.selected_indices)
-    sigma_sq = compute_unbiased_variance(Phi_train, model._y_train, model._result.coefficients)
+    sigma_sq = compute_unbiased_variance(
+        Phi_train, model._y_train, model._result.coefficients, weights
+    )
 
-    # (Phi^T Phi)^{-1} via SVD for stability
-    U, s, Vt = jnp.linalg.svd(Phi_train, full_matrices=False)
-    rcond = jnp.finfo(Phi_train.dtype).eps * max(Phi_train.shape)
-    cutoff = rcond * jnp.max(s)
-    s_inv_sq = jnp.where(s > cutoff, 1.0 / (s**2), 0.0)
-    PhiTPhiInv = Vt.T @ jnp.diag(s_inv_sq) @ Vt
+    PhiTPhiInv = _get_PhiTPhiInv(model)
 
     Phi_new = model.basis_library.evaluate_subset(X, model._result.selected_indices)
     y_pred = Phi_new @ model._result.coefficients
 
-    # Vectorised leverage: h_ii = phi_i^T @ (Phi^T Phi)^{-1} @ phi_i
+    # Vectorised leverage: h_ii = phi_i^T @ (Phi^T W Phi)^{-1} @ phi_i
     h = jnp.sum((Phi_new @ PhiTPhiInv) * Phi_new, axis=1)
     sigma = jnp.sqrt(jnp.maximum(sigma_sq * h, 0.0))
 
@@ -146,10 +164,10 @@ def _get_pred_and_sigma(
 
 
 def _get_PhiTPhiInv(model: SymbolicRegressor) -> jnp.ndarray:
-    """Return (Phi^T Phi)^{-1} for the training design matrix."""
-    Phi_train = model.basis_library.evaluate_subset(model._X_train, model._result.selected_indices)
-    U, s, Vt = jnp.linalg.svd(Phi_train, full_matrices=False)
-    rcond = jnp.finfo(Phi_train.dtype).eps * max(Phi_train.shape)
+    """Return (Phi^T W Phi)^{-1} for the training design matrix."""
+    Phi_train_w, _weights = _get_weighted_Phi_train(model)
+    U, s, Vt = jnp.linalg.svd(Phi_train_w, full_matrices=False)
+    rcond = jnp.finfo(Phi_train_w.dtype).eps * max(Phi_train_w.shape)
     cutoff = rcond * jnp.max(s)
     s_inv_sq = jnp.where(s > cutoff, 1.0 / (s**2), 0.0)
     return Vt.T @ jnp.diag(s_inv_sq) @ Vt
@@ -604,8 +622,11 @@ class ThompsonSampling(AcquisitionFunction):
         Phi_train = model.basis_library.evaluate_subset(
             model._X_train, model._result.selected_indices
         )
-        sigma_sq = compute_unbiased_variance(Phi_train, model._y_train, model._result.coefficients)
-        cov = compute_coeff_covariance(Phi_train, sigma_sq)
+        weights = getattr(model, "_sample_weight", None)
+        sigma_sq = compute_unbiased_variance(
+            Phi_train, model._y_train, model._result.coefficients, weights
+        )
+        cov = compute_coeff_covariance(Phi_train, sigma_sq, weights)
 
         beta_hat = np.array(model._result.coefficients)
         cov_np = np.array(cov)
@@ -662,7 +683,12 @@ class AOptimal(AcquisitionFunction):
         Phi_train = model.basis_library.evaluate_subset(
             model._X_train, model._result.selected_indices
         )
-        sigma_sq = compute_unbiased_variance(Phi_train, model._y_train, model._result.coefficients)
+        sigma_sq = compute_unbiased_variance(
+            Phi_train,
+            model._y_train,
+            model._result.coefficients,
+            getattr(model, "_sample_weight", None),
+        )
         PhiTPhiInv = _get_PhiTPhiInv(model)
         cov = sigma_sq * PhiTPhiInv
 
@@ -1069,6 +1095,7 @@ class ActiveLearner:
         # Save original state
         X_orig = self.model._X_train
         y_orig = self.model._y_train
+        w_orig = getattr(self.model, "_sample_weight", None)
         result_orig = self.model._result
 
         selected_indices = []
@@ -1095,19 +1122,29 @@ class ActiveLearner:
                 y_star = self.model.predict(x_star)
                 self.model._X_train = jnp.vstack([self.model._X_train, x_star])
                 self.model._y_train = jnp.concatenate([self.model._y_train, y_star])
+                if w_orig is not None:
+                    # The fantasised observation enters at unit weight -- i.e.
+                    # as precise as an average existing point.  It must be
+                    # appended, or the weights no longer line up with the rows.
+                    self.model._sample_weight = jnp.concatenate(
+                        [self.model._sample_weight, jnp.ones(1)]
+                    )
 
                 # Quick coefficient refit (not full selection)
                 Phi = self.model.basis_library.evaluate_subset(
                     self.model._X_train, self.model._result.selected_indices
                 )
-                coeffs = jnp.linalg.lstsq(Phi, self.model._y_train, rcond=None)[0]
-                from .selection import SelectionResult
+                from .selection import SelectionResult, fit_ols
+
+                coeffs, mse = fit_ols(
+                    Phi, self.model._y_train, sample_weight=self.model._sample_weight
+                )
 
                 self.model._result = SelectionResult(
                     coefficients=coeffs,
                     selected_indices=result_orig.selected_indices,
                     selected_names=result_orig.selected_names,
-                    mse=float(jnp.mean((self.model._y_train - Phi @ coeffs) ** 2)),
+                    mse=mse,
                     complexity=result_orig.complexity,
                     aic=result_orig.aic,
                     bic=result_orig.bic,
@@ -1118,6 +1155,7 @@ class ActiveLearner:
             # Restore original model state
             self.model._X_train = X_orig
             self.model._y_train = y_orig
+            self.model._sample_weight = w_orig
             self.model._result = result_orig
 
         selected_indices = np.array(selected_indices)

--- a/src/jaxsr/constraints.py
+++ b/src/jaxsr/constraints.py
@@ -21,6 +21,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from .utils import validate_sample_weight, whiten
+
 # =============================================================================
 # Constraint Types
 # =============================================================================
@@ -1895,6 +1897,7 @@ def fit_constrained_ols(
     basis_library: Any | None = None,
     selected_indices: Any | None = None,
     enforcement: str = "penalty",
+    sample_weight: jnp.ndarray | None = None,
 ) -> tuple[jnp.ndarray, float]:
     """
     Fit least squares with constraints.
@@ -1934,19 +1937,26 @@ def fit_constrained_ols(
         - ``"constrained"`` – scipy ``trust-constr`` with ``LinearConstraint``.
           Solver-tolerance guarantee (~1e-8).
         - ``"exact"`` – cvxpy QP.  Mathematical guarantee.  Requires ``cvxpy``.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights of shape ``(n_samples,)``.  Only the least-squares
+        part of the objective is weighted; the constraints are properties of
+        the fitted function over the design space and are evaluated on the
+        raw ``X``, so a down-weighted row still has to obey them.  The
+        returned MSE is the weighted MSE ``sum_i w_i r_i^2 / n``.
 
     Returns
     -------
     coefficients : jnp.ndarray
         Fitted coefficients.
     mse : float
-        Mean squared error.
+        (Weighted) mean squared error.
 
     Raises
     ------
     ValueError
-        If *enforcement* is not one of the valid levels, or if
-        ``enforcement='exact'`` is used with ``hard=True`` CUSTOM constraints.
+        If *enforcement* is not one of the valid levels, if
+        ``enforcement='exact'`` is used with ``hard=True`` CUSTOM constraints,
+        or if ``sample_weight`` is invalid.
     ImportError
         If ``enforcement='exact'`` and ``cvxpy`` is not installed.
     RuntimeError
@@ -1964,11 +1974,17 @@ def fit_constrained_ols(
     fixed_idx_set = {f[0] for f in fixed}
 
     n_total = len(basis_names)
-    Phi_np = np.array(Phi)
-    y_np = np.array(y)
+
+    # Whitened copies drive every least-squares computation below; the raw
+    # ``Phi`` is kept for constraint evaluation, which must not be weighted.
+    weights = validate_sample_weight(sample_weight, Phi.shape[0])
+    Phi_fit = whiten(Phi, weights)
+    y_fit = whiten(jnp.asarray(y), weights)
+    Phi_np = np.array(Phi_fit)
+    y_np = np.array(y_fit)
 
     # Initial OLS solution
-    coeffs_jax, _, _, _ = jnp.linalg.lstsq(Phi, y, rcond=None)
+    coeffs_jax, _, _, _ = jnp.linalg.lstsq(Phi_fit, y_fit, rcond=None)
     coeffs_init = np.array(coeffs_jax)
 
     # Apply hard sign/fixed constraints to initial guess
@@ -2020,17 +2036,19 @@ def fit_constrained_ols(
     fixed_jax = [(idx, jnp.asarray(val)) for idx, val in fixed]
     free_indices_arr = jnp.array(free_indices, dtype=jnp.int32)
 
-    # Pre-compute perturbed design matrices for constraint evaluation
+    # Pre-compute perturbed design matrices for constraint evaluation.  These
+    # use the *raw* Phi: a constraint such as "monotonic in x" is a statement
+    # about the fitted function, not about how much each row was trusted.
     constraint_data = _precompute_constraint_data(
         evaluator, X_jax, basis_library, selected_indices, Phi
     )
 
-    y_jax = jnp.array(y)
+    y_jax = y_fit
 
     # Dispatch to the chosen enforcement solver
     if enforcement == "penalty":
         return _fit_penalty(
-            Phi=Phi,
+            Phi=Phi_fit,
             y_jax=y_jax,
             evaluator=evaluator,
             x0=x0,
@@ -2047,7 +2065,7 @@ def fit_constrained_ols(
         )
     elif enforcement == "constrained":
         return _fit_trust_constr(
-            Phi=Phi,
+            Phi=Phi_fit,
             y_jax=y_jax,
             evaluator=evaluator,
             x0=x0,
@@ -2064,7 +2082,7 @@ def fit_constrained_ols(
         )
     else:  # enforcement == "exact"
         return _fit_qp_exact(
-            Phi=Phi,
+            Phi=Phi_fit,
             y_jax=y_jax,
             evaluator=evaluator,
             free_indices=free_indices,

--- a/src/jaxsr/metrics.py
+++ b/src/jaxsr/metrics.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Any
 import jax.numpy as jnp
 import numpy as np
 
+from .utils import validate_sample_weight, weighted_mean, whiten
+
 if TYPE_CHECKING:
     from .regressor import SymbolicRegressor
 
@@ -23,6 +25,27 @@ _np_trapezoid = getattr(np, "trapezoid", getattr(np, "trapz", None))
 # =============================================================================
 # Information Criteria
 # =============================================================================
+#
+# Effective sample size under sample weights
+# ------------------------------------------
+# JAXSR treats ``sample_weight`` as *relative precision*: observation ``i`` is
+# assumed to have variance ``sigma^2 / w_i``.  Weights are normalised to sum to
+# ``n`` (see :func:`jaxsr.utils.validate_sample_weight`) and the ``n_samples``
+# passed to every criterion below stays the nominal ``n`` -- the number of
+# observations actually measured.  Consequences worth knowing:
+#
+# * The criteria are invariant to the overall scale of the weights, so ``w`` and
+#   ``1000 * w`` select the same model.
+# * Weighting does not manufacture or destroy observations.  ``k * log(n)`` in
+#   BIC penalises complexity by how much data was collected, not by how much of
+#   it happened to be precise.  This is why row duplication is *not* a valid way
+#   to emulate weights: it inflates ``n`` and shifts every criterion.
+# * The MSE fed to the criteria is the weighted MSE ``sum_i w_i r_i^2 / n``.
+#
+# If most of the weight sits on a handful of rows, the nominal ``n`` overstates
+# how much information the comparison rests on;
+# :func:`jaxsr.utils.effective_sample_size` reports the Kish effective sample
+# size for that diagnosis.
 
 # Smallest MSE that still produces a finite log-likelihood.
 _MSE_FLOOR = float(np.finfo(float).tiny)
@@ -271,6 +294,12 @@ def compute_information_criterion(
     -------
     ic : float
         Information criterion value (lower is better).
+
+    Notes
+    -----
+    Under sample weights, pass the *nominal* number of observations as
+    ``n_samples`` and the weighted MSE ``sum_i w_i r_i^2 / n`` as ``mse``.
+    See the effective-sample-size note at the top of this module.
     """
     criteria = {
         "aic": compute_aic,
@@ -298,6 +327,7 @@ def cross_validate(
     cv: int = 5,
     scoring: str = "neg_mse",
     random_state: int | None = None,
+    sample_weight: jnp.ndarray | None = None,
 ) -> dict[str, Any]:
     """
     Perform k-fold cross-validation.
@@ -316,6 +346,11 @@ def cross_validate(
         Scoring metric: "neg_mse", "neg_mae", "r2".
     random_state : int, optional
         Random seed for fold splitting.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.  Weights follow their rows into the folds: each
+        fold is fitted on its training weights and scored with its test
+        weights, so down-weighted observations neither drive the fit nor
+        dominate the score.
 
     Returns
     -------
@@ -325,10 +360,16 @@ def cross_validate(
         - "train_scores": array of train scores for each fold
         - "mean_test_score": mean test score
         - "std_test_score": std of test scores
+
+    Raises
+    ------
+    ValueError
+        If ``scoring`` is unknown or ``sample_weight`` is invalid.
     """
     from .regressor import _clone_estimator
 
     n_samples = X.shape[0]
+    weights = validate_sample_weight(sample_weight, n_samples)
     rng = np.random.RandomState(random_state)
     indices = rng.permutation(n_samples)
 
@@ -337,13 +378,9 @@ def cross_validate(
     train_scores = []
 
     scoring_funcs = {
-        "neg_mse": lambda y_true, y_pred: -float(jnp.mean((y_true - y_pred) ** 2)),
-        "neg_mae": lambda y_true, y_pred: -float(jnp.mean(jnp.abs(y_true - y_pred))),
-        "r2": lambda y_true, y_pred: float(
-            1
-            - jnp.sum((y_true - y_pred) ** 2)
-            / jnp.maximum(jnp.sum((y_true - jnp.mean(y_true)) ** 2), 1e-10)
-        ),
+        "neg_mse": lambda y_true, y_pred, w: -compute_mse(y_true, y_pred, w),
+        "neg_mae": lambda y_true, y_pred, w: -compute_mae(y_true, y_pred, w),
+        "r2": lambda y_true, y_pred, w: compute_r2(y_true, y_pred, w),
     }
 
     if scoring not in scoring_funcs:
@@ -360,16 +397,25 @@ def cross_validate(
 
         X_train, X_test = X[train_idx], X[test_idx]
         y_train, y_test = y[train_idx], y[test_idx]
+        w_train = None if weights is None else weights[train_idx]
+        w_test = None if weights is None else weights[test_idx]
+        for split, w_split in (("train", w_train), ("test", w_test)):
+            if w_split is not None and float(jnp.sum(w_split)) <= 0:
+                raise ValueError(
+                    f"Fold {i} has zero total sample_weight in its {split} split; "
+                    "cross-validation cannot score it. Drop the zero-weight rows "
+                    "or use fewer folds."
+                )
 
         # Clone and fit model
         model_clone = _clone_estimator(model)
-        model_clone.fit(X_train, y_train)
+        model_clone.fit(X_train, y_train, sample_weight=w_train)
 
         y_pred_test = model_clone.predict(X_test)
         y_pred_train = model_clone.predict(X_train)
 
-        test_scores.append(score_func(y_test, y_pred_test))
-        train_scores.append(score_func(y_train, y_pred_train))
+        test_scores.append(score_func(y_test, y_pred_test, w_test))
+        train_scores.append(score_func(y_train, y_pred_train, w_train))
 
     test_scores = np.array(test_scores)
     train_scores = np.array(train_scores)
@@ -389,6 +435,7 @@ def compute_cv_score(
     y: jnp.ndarray,
     cv: int = 5,
     random_state: int | None = None,
+    sample_weight: jnp.ndarray | None = None,
 ) -> float:
     """
     Compute cross-validation MSE for a design matrix.
@@ -405,13 +452,22 @@ def compute_cv_score(
         Number of folds.
     random_state : int, optional
         Random seed.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.  Each fold is fitted by weighted least squares on
+        its training weights and scored by weighted MSE on its test weights.
 
     Returns
     -------
     cv_mse : float
         Mean cross-validation MSE.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
     n_samples = Phi.shape[0]
+    weights = validate_sample_weight(sample_weight, n_samples)
     rng = np.random.RandomState(random_state)
     indices = rng.permutation(n_samples)
 
@@ -427,12 +483,15 @@ def compute_cv_score(
 
         Phi_train, Phi_test = Phi[train_idx], Phi[test_idx]
         y_train, y_test = y[train_idx], y[test_idx]
+        w_train = None if weights is None else weights[train_idx]
+        w_test = None if weights is None else weights[test_idx]
 
-        # Solve least squares
-        coeffs, _, _, _ = jnp.linalg.lstsq(Phi_train, y_train, rcond=None)
+        # Solve (weighted) least squares
+        coeffs, _, _, _ = jnp.linalg.lstsq(
+            whiten(Phi_train, w_train), whiten(y_train, w_train), rcond=None
+        )
         y_pred = Phi_test @ coeffs
-        mse = float(jnp.mean((y_test - y_pred) ** 2))
-        mse_scores.append(mse)
+        mse_scores.append(compute_mse(y_test, y_pred, w_test))
 
     return float(np.mean(mse_scores))
 
@@ -441,6 +500,7 @@ def compute_loo_mse(
     Phi: jnp.ndarray,
     y: jnp.ndarray,
     coefficients: jnp.ndarray,
+    sample_weight: jnp.ndarray | None = None,
 ) -> float:
     """
     Compute leave-one-out MSE efficiently using Sherman-Morrison formula.
@@ -455,32 +515,41 @@ def compute_loo_mse(
         Target values.
     coefficients : jnp.ndarray
         Fitted coefficients.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.  The leverages become the weighted-least-squares
+        leverages ``w_i * phi_i^T (Phi^T W Phi)^-1 phi_i`` and the LOO
+        residuals are averaged with the same weights.
 
     Returns
     -------
     loo_mse : float
         Leave-one-out mean squared error.
-    """
-    y_pred = Phi @ coefficients
-    residuals = y - y_pred
 
-    # Hat matrix diagonal: h_ii = Phi_i @ (Phi.T @ Phi)^-1 @ Phi_i.T
-    # Using pseudo-inverse for numerical stability
-    Phi_pinv = jnp.linalg.pinv(Phi)
-    H = Phi @ Phi_pinv
-    h_diag = jnp.diag(H)
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
+    """
+    w = validate_sample_weight(sample_weight, len(y))
+    residuals = y - Phi @ coefficients
+
+    # Hat matrix diagonal of the whitened problem:
+    #   h_ii = w_i * phi_i^T (Phi^T W Phi)^-1 phi_i
+    # which reduces to the ordinary leverage when the weights are all 1.
+    Phi_w = whiten(Phi, w)
+    h_diag = jnp.sum(Phi_w * jnp.linalg.pinv(Phi_w).T, axis=1)
 
     # LOO residual: e_i / (1 - h_ii)
     loo_residuals = residuals / (1 - h_diag + 1e-10)
-    loo_mse = jnp.mean(loo_residuals**2)
 
-    return float(loo_mse)
+    return float(weighted_mean(loo_residuals**2, w))
 
 
 def compute_press(
     Phi: jnp.ndarray,
     y: jnp.ndarray,
     coefficients: jnp.ndarray,
+    sample_weight: jnp.ndarray | None = None,
 ) -> float:
     """
     Compute PRESS (Predicted Residual Error Sum of Squares).
@@ -495,13 +564,20 @@ def compute_press(
         Target values.
     coefficients : jnp.ndarray
         Fitted coefficients.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights; see :func:`compute_loo_mse`.
 
     Returns
     -------
     press : float
         PRESS statistic.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
-    return compute_loo_mse(Phi, y, coefficients) * len(y)
+    return compute_loo_mse(Phi, y, coefficients, sample_weight) * len(y)
 
 
 # =============================================================================
@@ -509,25 +585,134 @@ def compute_press(
 # =============================================================================
 
 
-def compute_mse(y_true: jnp.ndarray, y_pred: jnp.ndarray) -> float:
-    """Compute mean squared error."""
-    return float(jnp.mean((y_true - y_pred) ** 2))
+def compute_mse(
+    y_true: jnp.ndarray,
+    y_pred: jnp.ndarray,
+    sample_weight: jnp.ndarray | None = None,
+) -> float:
+    """
+    Compute mean squared error, optionally weighted.
+
+    Parameters
+    ----------
+    y_true : jnp.ndarray
+        True values of shape ``(n_samples,)``.
+    y_pred : jnp.ndarray
+        Predicted values of shape ``(n_samples,)``.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.  Weights are normalised to sum to ``n_samples``,
+        so the result is ``sum_i w_i r_i^2 / n``.
+
+    Returns
+    -------
+    float
+        (Weighted) mean squared error.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` has the wrong length or contains negative or
+        non-finite values.
+    """
+    w = validate_sample_weight(sample_weight, len(y_true))
+    return float(weighted_mean((y_true - y_pred) ** 2, w))
 
 
-def compute_rmse(y_true: jnp.ndarray, y_pred: jnp.ndarray) -> float:
-    """Compute root mean squared error."""
-    return float(jnp.sqrt(jnp.mean((y_true - y_pred) ** 2)))
+def compute_rmse(
+    y_true: jnp.ndarray,
+    y_pred: jnp.ndarray,
+    sample_weight: jnp.ndarray | None = None,
+) -> float:
+    """
+    Compute root mean squared error, optionally weighted.
+
+    Parameters
+    ----------
+    y_true : jnp.ndarray
+        True values.
+    y_pred : jnp.ndarray
+        Predicted values.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.
+
+    Returns
+    -------
+    float
+        (Weighted) root mean squared error.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
+    """
+    return float(np.sqrt(compute_mse(y_true, y_pred, sample_weight)))
 
 
-def compute_mae(y_true: jnp.ndarray, y_pred: jnp.ndarray) -> float:
-    """Compute mean absolute error."""
-    return float(jnp.mean(jnp.abs(y_true - y_pred)))
+def compute_mae(
+    y_true: jnp.ndarray,
+    y_pred: jnp.ndarray,
+    sample_weight: jnp.ndarray | None = None,
+) -> float:
+    """
+    Compute mean absolute error, optionally weighted.
+
+    Parameters
+    ----------
+    y_true : jnp.ndarray
+        True values.
+    y_pred : jnp.ndarray
+        Predicted values.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.
+
+    Returns
+    -------
+    float
+        (Weighted) mean absolute error.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
+    """
+    w = validate_sample_weight(sample_weight, len(y_true))
+    return float(weighted_mean(jnp.abs(y_true - y_pred), w))
 
 
-def compute_r2(y_true: jnp.ndarray, y_pred: jnp.ndarray) -> float:
-    """Compute R-squared (coefficient of determination)."""
-    ss_res = jnp.sum((y_true - y_pred) ** 2)
-    ss_tot = jnp.sum((y_true - jnp.mean(y_true)) ** 2)
+def compute_r2(
+    y_true: jnp.ndarray,
+    y_pred: jnp.ndarray,
+    sample_weight: jnp.ndarray | None = None,
+) -> float:
+    """
+    Compute R-squared (coefficient of determination), optionally weighted.
+
+    Parameters
+    ----------
+    y_true : jnp.ndarray
+        True values.
+    y_pred : jnp.ndarray
+        Predicted values.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.  Both the residual and the total sum of squares
+        are weighted, and the total is taken about the *weighted* mean of
+        ``y_true``.
+
+    Returns
+    -------
+    float
+        (Weighted) R-squared.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
+    """
+    w = validate_sample_weight(sample_weight, len(y_true))
+    weights = jnp.ones_like(y_true) if w is None else w
+    y_bar = weighted_mean(y_true, w)
+    ss_res = jnp.sum(weights * (y_true - y_pred) ** 2)
+    ss_tot = jnp.sum(weights * (y_true - y_bar) ** 2)
     return float(1 - ss_res / (ss_tot + 1e-10))
 
 
@@ -535,6 +720,7 @@ def compute_adjusted_r2(
     y_true: jnp.ndarray,
     y_pred: jnp.ndarray,
     n_params: int,
+    sample_weight: jnp.ndarray | None = None,
 ) -> float:
     """
     Compute adjusted R-squared.
@@ -549,15 +735,23 @@ def compute_adjusted_r2(
         Predicted values.
     n_params : int
         Number of model parameters.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.  ``n`` remains the nominal sample count; only R²
+        itself is weighted.
 
     Returns
     -------
     adj_r2 : float
         Adjusted R-squared.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
     n = len(y_true)
     k = n_params
-    r2 = compute_r2(y_true, y_pred)
+    r2 = compute_r2(y_true, y_pred, sample_weight)
 
     if n - k - 1 <= 0:
         return float("-inf")
@@ -566,26 +760,55 @@ def compute_adjusted_r2(
 
 
 def compute_max_error(y_true: jnp.ndarray, y_pred: jnp.ndarray) -> float:
-    """Compute maximum absolute error."""
+    """Compute maximum absolute error (unweighted -- a max is not an average)."""
     return float(jnp.max(jnp.abs(y_true - y_pred)))
 
 
-def compute_mape(y_true: jnp.ndarray, y_pred: jnp.ndarray) -> float:
+def compute_mape(
+    y_true: jnp.ndarray,
+    y_pred: jnp.ndarray,
+    sample_weight: jnp.ndarray | None = None,
+) -> float:
     """
-    Compute mean absolute percentage error.
+    Compute mean absolute percentage error, optionally weighted.
 
     MAPE = mean(|y_true - y_pred| / |y_true|) * 100
+
+    Parameters
+    ----------
+    y_true : jnp.ndarray
+        True values.  Entries with ``|y_true| <= 1e-10`` are skipped.
+    y_pred : jnp.ndarray
+        Predicted values.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.
+
+    Returns
+    -------
+    float
+        (Weighted) MAPE in percent, or ``inf`` if every target is ~0.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
+    w = validate_sample_weight(sample_weight, len(y_true))
     mask = jnp.abs(y_true) > 1e-10
-    if not jnp.any(mask):
+    if not bool(jnp.any(mask)):
         return float("inf")
-    return float(jnp.mean(jnp.abs((y_true - y_pred) / y_true)[mask]) * 100)
+    pct = jnp.abs((y_true - y_pred) / y_true)[mask]
+    w_masked = None if w is None else w[mask]
+    if w_masked is not None and float(jnp.sum(w_masked)) <= 0:
+        return float("inf")
+    return float(weighted_mean(pct, w_masked) * 100)
 
 
 def compute_all_metrics(
     y_true: jnp.ndarray,
     y_pred: jnp.ndarray,
     n_params: int,
+    sample_weight: jnp.ndarray | None = None,
 ) -> dict[str, float]:
     """
     Compute all standard regression metrics.
@@ -598,23 +821,43 @@ def compute_all_metrics(
         Predicted values.
     n_params : int
         Number of model parameters.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.  Every averaged metric is weighted;
+        ``"max_error"`` is taken over the samples with non-zero weight, since
+        a maximum has no weighted analogue.
 
     Returns
     -------
     metrics : dict
         Dictionary containing all metrics.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
     n = len(y_true)
-    mse = compute_mse(y_true, y_pred)
+    w = validate_sample_weight(sample_weight, n)
+    mse = compute_mse(y_true, y_pred, w)
+
+    if w is None:
+        max_error = compute_max_error(y_true, y_pred)
+    else:
+        nonzero = w > 0
+        max_error = (
+            compute_max_error(y_true[nonzero], y_pred[nonzero])
+            if bool(jnp.any(nonzero))
+            else float("nan")
+        )
 
     return {
         "mse": mse,
-        "rmse": compute_rmse(y_true, y_pred),
-        "mae": compute_mae(y_true, y_pred),
-        "r2": compute_r2(y_true, y_pred),
-        "adjusted_r2": compute_adjusted_r2(y_true, y_pred, n_params),
-        "max_error": compute_max_error(y_true, y_pred),
-        "mape": compute_mape(y_true, y_pred),
+        "rmse": compute_rmse(y_true, y_pred, w),
+        "mae": compute_mae(y_true, y_pred, w),
+        "r2": compute_r2(y_true, y_pred, w),
+        "adjusted_r2": compute_adjusted_r2(y_true, y_pred, n_params, w),
+        "max_error": max_error,
+        "mape": compute_mape(y_true, y_pred, w),
         "aic": compute_aic(n, n_params, mse),
         "aicc": compute_aicc(n, n_params, mse),
         "bic": compute_bic(n, n_params, mse),

--- a/src/jaxsr/regressor.py
+++ b/src/jaxsr/regressor.py
@@ -39,6 +39,7 @@ from .uncertainty import (
 from .uncertainty import (
     prediction_interval as _prediction_interval,
 )
+from .utils import effective_sample_size, validate_sample_weight, whiten
 
 # =============================================================================
 # Helpers
@@ -208,6 +209,7 @@ class SymbolicRegressor(_SklearnCompatMixin):
         self._selection_path: SelectionPath | None = None
         self._X_train: jnp.ndarray | None = None
         self._y_train: jnp.ndarray | None = None
+        self._sample_weight: jnp.ndarray | None = None
         self._is_fitted = False
 
     @property
@@ -242,7 +244,7 @@ class SymbolicRegressor(_SklearnCompatMixin):
 
     @property
     def metrics_(self) -> dict[str, float]:
-        """Evaluation metrics."""
+        """Evaluation metrics (weighted when the model was fitted with weights)."""
         self._check_is_fitted()
         return {
             "mse": self._result.mse,
@@ -251,6 +253,53 @@ class SymbolicRegressor(_SklearnCompatMixin):
             "aicc": self._result.aicc,
             "r2": self._compute_r2(),
         }
+
+    @property
+    def sample_weight_(self) -> jnp.ndarray | None:
+        """
+        Normalised training weights, or ``None`` if the fit was unweighted.
+
+        Returns
+        -------
+        jnp.ndarray or None
+            Weights of shape ``(n_samples,)`` scaled to sum to ``n_samples``.
+            These are the weights actually used, not the array passed to
+            :meth:`fit` -- only the ratios between weights carry meaning.
+
+        Raises
+        ------
+        RuntimeError
+            If the model has not been fitted.
+        """
+        self._check_is_fitted()
+        return self._sample_weight
+
+    @property
+    def effective_sample_size_(self) -> float:
+        """
+        Kish effective sample size of the training weights.
+
+        Returns
+        -------
+        float
+            ``(sum w)^2 / sum w^2``, equal to ``n`` for an unweighted fit and
+            smaller when the weights are uneven.
+
+        Raises
+        ------
+        RuntimeError
+            If the model has not been fitted.
+
+        Notes
+        -----
+        This is a diagnostic, not an input: AIC/BIC/AICc use the nominal ``n``
+        (see :func:`jaxsr.metrics.compute_information_criterion`).  When this
+        number is far below ``n``, the criteria are comparing models on much
+        less information than ``n`` suggests, and the usual asymptotic
+        intuitions about BIC's penalty are correspondingly weaker.
+        """
+        self._check_is_fitted()
+        return effective_sample_size(self._sample_weight, len(self._y_train))
 
     @property
     def pareto_front_(self) -> list[SelectionResult]:
@@ -308,11 +357,11 @@ class SymbolicRegressor(_SklearnCompatMixin):
             raise RuntimeError("Model not fitted. Call fit() first.")
 
     def _compute_r2(self) -> float:
-        """Compute R² score on training data."""
+        """Compute (weighted) R² score on training data."""
+        from .metrics import compute_r2
+
         y_pred = self.predict(self._X_train)
-        ss_res = jnp.sum((self._y_train - y_pred) ** 2)
-        ss_tot = jnp.sum((self._y_train - jnp.mean(self._y_train)) ** 2)
-        return float(1 - ss_res / (ss_tot + 1e-10))
+        return compute_r2(self._y_train, y_pred, self._sample_weight)
 
     def fit(
         self,
@@ -330,12 +379,49 @@ class SymbolicRegressor(_SklearnCompatMixin):
         y : array-like of shape (n_samples,)
             Target values.
         sample_weight : array-like of shape (n_samples,), optional
-            Sample weights (not yet implemented).
+            Per-sample weights.  Observation ``i`` is treated as having
+            variance ``sigma^2 / w_i``, so the fit minimises
+            ``sum_i w_i (y_i - f(x_i))^2``.  Typical sources are measurement
+            variances (``w = 1 / var``), replicate counts, or a smooth taper
+            that de-emphasises rows carrying little information.
 
         Returns
         -------
         self : SymbolicRegressor
             Fitted model.
+
+        Raises
+        ------
+        ValueError
+            If ``X`` and ``y`` disagree on the number of samples, if
+            ``basis_library`` is not set, if ``X`` has the wrong number of
+            features, or if ``sample_weight`` has the wrong length or
+            contains negative or non-finite values.
+
+        Notes
+        -----
+        Weights are used consistently, not just for the final coefficients:
+        term selection, the reported MSE, AIC/BIC/AICc, constraint refitting,
+        R², the classical intervals and the bootstrap all run on the weighted
+        problem.
+
+        Only the *ratios* between weights matter.  They are normalised to
+        average 1 internally, so ``w``, ``2 * w`` and ``w / 1000`` all give
+        the same model and the same information criteria, and the effective
+        sample size in AIC/BIC stays the nominal ``n``.  Weighting therefore
+        never manufactures observations -- which is also why duplicating rows
+        is *not* an equivalent trick: it inflates ``n`` and shifts every
+        criterion.  See :attr:`effective_sample_size_` for a diagnostic of how
+        much information the weights actually leave.
+
+        A weight of exactly 0 excludes a row from the fit while keeping it in
+        ``n``.  If you mean to drop the row entirely, drop it from ``X`` and
+        ``y`` instead.
+
+        Examples
+        --------
+        >>> variances = np.array([0.1, 0.1, 4.0, 4.0])  # doctest: +SKIP
+        >>> model.fit(X, y, sample_weight=1.0 / variances)  # doctest: +SKIP
         """
         # Convert to JAX arrays
         X = jnp.atleast_2d(jnp.asarray(X))
@@ -355,8 +441,11 @@ class SymbolicRegressor(_SklearnCompatMixin):
                 f"{self.basis_library.n_features}"
             )
 
+        weights = validate_sample_weight(sample_weight, len(y))
+
         self._X_train = X
         self._y_train = y
+        self._sample_weight = weights
 
         # Evaluate basis functions
         Phi = self.basis_library.evaluate(X)
@@ -409,6 +498,7 @@ class SymbolicRegressor(_SklearnCompatMixin):
             max_terms=self.max_terms,
             information_criterion=self.information_criterion,
             regularization=self.regularization,
+            sample_weight=weights,
             **extra_kw,
         )
 
@@ -493,13 +583,19 @@ class SymbolicRegressor(_SklearnCompatMixin):
             Design matrix (invalid columns already zeroed).
         y : jnp.ndarray
             Target values.
+
+        Notes
+        -----
+        Contributions are measured on the *weighted* design matrix, so a term
+        that only matters where the data was down-weighted counts as small --
+        the same convention the fit itself uses.
         """
         indices = [int(i) for i in np.asarray(self._result.selected_indices)]
         if len(indices) <= 1:
             return
 
         coeffs = np.asarray(self._result.coefficients)
-        Phi_sub = np.asarray(Phi[:, jnp.asarray(indices)])
+        Phi_sub = np.asarray(whiten(Phi[:, jnp.asarray(indices)], self._sample_weight))
         contribution = np.abs(coeffs) * np.linalg.norm(Phi_sub, axis=0)
         max_contribution = float(contribution.max())
         if max_contribution <= 0:
@@ -532,10 +628,12 @@ class SymbolicRegressor(_SklearnCompatMixin):
         -------
         SelectionResult
             Result for the retained terms with recomputed MSE and information
-            criteria.
+            criteria.  The refit honours ``sample_weight`` from :meth:`fit`,
+            and the MSE it reports is the weighted one, so the recomputed
+            criteria stay comparable with the rest of the selection path.
         """
         keep_arr = jnp.asarray(keep)
-        coeffs, mse = fit_ols(Phi[:, keep_arr], y)
+        coeffs, mse = fit_ols(Phi[:, keep_arr], y, sample_weight=self._sample_weight)
         names = [self.basis_library.names[i] for i in keep]
         complexity = int(sum(self.basis_library.complexities[i] for i in keep))
         n, k = len(y), len(coeffs)
@@ -581,6 +679,7 @@ class SymbolicRegressor(_SklearnCompatMixin):
             basis_library=self.basis_library,
             selected_indices=indices,
             enforcement=self.constraint_enforcement,
+            sample_weight=self._sample_weight,
         )
 
         # Update result with recalculated information criteria
@@ -649,7 +748,12 @@ class SymbolicRegressor(_SklearnCompatMixin):
         Phi = self.basis_library.evaluate_subset(X, self._result.selected_indices)
         return Phi @ self._result.coefficients
 
-    def score(self, X: jnp.ndarray, y: jnp.ndarray) -> float:
+    def score(
+        self,
+        X: jnp.ndarray,
+        y: jnp.ndarray,
+        sample_weight: jnp.ndarray | None = None,
+    ) -> float:
         """
         Compute R² score.
 
@@ -659,18 +763,28 @@ class SymbolicRegressor(_SklearnCompatMixin):
             Test samples.
         y : array-like
             True values.
+        sample_weight : array-like of shape (n_samples,), optional
+            Weights for *these* samples.  Not inherited from :meth:`fit` --
+            ``X`` and ``y`` here are usually different data, so their weights
+            have to come with them.
 
         Returns
         -------
         score : float
-            R² score.
+            (Weighted) R² score.
+
+        Raises
+        ------
+        RuntimeError
+            If the model has not been fitted.
+        ValueError
+            If ``sample_weight`` is invalid.
         """
+        from .metrics import compute_r2
+
         self._check_is_fitted()
         y = jnp.asarray(y).ravel()
-        y_pred = self.predict(X)
-        ss_res = jnp.sum((y - y_pred) ** 2)
-        ss_tot = jnp.sum((y - jnp.mean(y)) ** 2)
-        return float(1 - ss_res / (ss_tot + 1e-10))
+        return compute_r2(y, self.predict(X), sample_weight)
 
     # =================================================================
     # Uncertainty Quantification
@@ -704,29 +818,36 @@ class SymbolicRegressor(_SklearnCompatMixin):
         Returns
         -------
         sigma : float
-            Noise standard deviation estimate.
+            Noise standard deviation estimate.  Under sample weights this is
+            the noise level of a *unit-weight* observation: row ``i`` is
+            modelled with variance ``sigma^2 / w_i``.
         """
         self._check_is_fitted()
         self._warn_if_constrained_or_regularized()
         Phi = self._get_Phi_train()
-        sigma_sq = compute_unbiased_variance(Phi, self._y_train, self._result.coefficients)
+        sigma_sq = compute_unbiased_variance(
+            Phi, self._y_train, self._result.coefficients, self._sample_weight
+        )
         return float(jnp.sqrt(sigma_sq))
 
     @property
     def covariance_matrix_(self) -> jnp.ndarray:
         """
-        Coefficient covariance matrix: s^2 * (Phi^T Phi)^{-1}.
+        Coefficient covariance matrix: s^2 * (Phi^T W Phi)^{-1}.
 
         Returns
         -------
         cov : jnp.ndarray
-            Covariance matrix of shape (p, p).
+            Covariance matrix of shape (p, p).  ``W`` is the diagonal matrix
+            of training weights (the identity for an unweighted fit).
         """
         self._check_is_fitted()
         self._warn_if_constrained_or_regularized()
         Phi = self._get_Phi_train()
-        sigma_sq = compute_unbiased_variance(Phi, self._y_train, self._result.coefficients)
-        return compute_coeff_covariance(Phi, sigma_sq)
+        sigma_sq = compute_unbiased_variance(
+            Phi, self._y_train, self._result.coefficients, self._sample_weight
+        )
+        return compute_coeff_covariance(Phi, sigma_sq, self._sample_weight)
 
     def coefficient_intervals(self, alpha: float = 0.05) -> dict[str, tuple]:
         """
@@ -741,6 +862,8 @@ class SymbolicRegressor(_SklearnCompatMixin):
         -------
         intervals : dict
             {name: (estimate, lower, upper, se)} for each coefficient.
+            Standard errors come from the weighted covariance matrix when the
+            model was fitted with ``sample_weight``.
         """
         self._check_is_fitted()
         self._warn_if_constrained_or_regularized()
@@ -751,6 +874,7 @@ class SymbolicRegressor(_SklearnCompatMixin):
             self._result.coefficients,
             self._result.selected_names,
             alpha,
+            self._sample_weight,
         )
 
     def predict_interval(
@@ -774,6 +898,13 @@ class SymbolicRegressor(_SklearnCompatMixin):
             Lower prediction interval bound.
         upper : jnp.ndarray
             Upper prediction interval bound.
+
+        Notes
+        -----
+        For a weighted fit the interval is for a new observation of *unit*
+        weight, i.e. one measured as precisely as an average training point.
+        Rescale by ``1 / sqrt(w_new)`` if the new observation has a known
+        precision of its own.
         """
         self._check_is_fitted()
         self._warn_if_constrained_or_regularized()
@@ -786,6 +917,7 @@ class SymbolicRegressor(_SklearnCompatMixin):
             self._result.coefficients,
             Phi_new,
             alpha,
+            self._sample_weight,
         )
         return result["y_pred"], result["pred_lower"], result["pred_upper"]
 
@@ -822,6 +954,7 @@ class SymbolicRegressor(_SklearnCompatMixin):
             self._result.coefficients,
             Phi_new,
             alpha,
+            self._sample_weight,
         )
         return result["y_pred"], result["conf_lower"], result["conf_upper"]
 
@@ -923,6 +1056,7 @@ class SymbolicRegressor(_SklearnCompatMixin):
         X_new: jnp.ndarray,
         y_new: jnp.ndarray,
         refit: bool = True,
+        sample_weight_new: jnp.ndarray | None = None,
     ) -> SymbolicRegressor:
         """
         Update model with new data points.
@@ -935,11 +1069,24 @@ class SymbolicRegressor(_SklearnCompatMixin):
             New target values.
         refit : bool
             If True, rerun full selection. If False, only refit coefficients.
+        sample_weight_new : array-like of shape (n_new,), optional
+            Weights for the new samples, on the same scale as the weights
+            passed to :meth:`fit`.  Defaults to 1 per new sample.  Omitting it
+            for a weighted model therefore adds the new points at unit weight,
+            which is what "as precise as an average existing point" means.
 
         Returns
         -------
         self : SymbolicRegressor
             Updated model.
+
+        Raises
+        ------
+        RuntimeError
+            If the model has not been fitted.
+        ValueError
+            If ``sample_weight_new`` has the wrong length or contains negative
+            or non-finite values.
         """
         self._check_is_fitted()
 
@@ -950,14 +1097,33 @@ class SymbolicRegressor(_SklearnCompatMixin):
         X_combined = jnp.vstack([self._X_train, X_new])
         y_combined = jnp.concatenate([self._y_train, y_new])
 
+        # Combine weights.  An unweighted model with unweighted new points
+        # stays unweighted; anything else needs an explicit weight vector.
+        # The new weights are validated but not rescaled: they are on the same
+        # scale as the stored (already normalised) ones, and normalising the
+        # fragment alone would change what it means relative to them.
+        w_new = validate_sample_weight(
+            sample_weight_new, len(y_new), "sample_weight_new", normalize=False
+        )
+        if self._sample_weight is None and w_new is None:
+            w_combined = None
+        else:
+            w_old = (
+                self._sample_weight
+                if self._sample_weight is not None
+                else jnp.ones(len(self._y_train))
+            )
+            w_new = w_new if w_new is not None else jnp.ones(len(y_new))
+            w_combined = jnp.concatenate([w_old, w_new])
+
         if refit:
             # Full refit
-            return self.fit(X_combined, y_combined)
+            return self.fit(X_combined, y_combined, sample_weight=w_combined)
         else:
             # Only refit coefficients with existing selection
             Phi = self.basis_library.evaluate_subset(X_combined, self._result.selected_indices)
-            coeffs, mse = (
-                fit_constrained_ols(
+            if self.constraints:
+                coeffs, mse = fit_constrained_ols(
                     Phi=Phi,
                     y=y_combined,
                     constraints=self.constraints or Constraints(),
@@ -967,18 +1133,10 @@ class SymbolicRegressor(_SklearnCompatMixin):
                     basis_library=self.basis_library,
                     selected_indices=self._result.selected_indices,
                     enforcement=self.constraint_enforcement,
+                    sample_weight=w_combined,
                 )
-                if self.constraints
-                else (
-                    jnp.linalg.lstsq(Phi, y_combined, rcond=None)[0],
-                    float(
-                        jnp.mean(
-                            (y_combined - Phi @ jnp.linalg.lstsq(Phi, y_combined, rcond=None)[0])
-                            ** 2
-                        )
-                    ),
-                )
-            )
+            else:
+                coeffs, mse = fit_ols(Phi, y_combined, sample_weight=w_combined)
 
             # Recalculate IC values from the new MSE and sample count
             n_new = len(y_combined)
@@ -999,6 +1157,7 @@ class SymbolicRegressor(_SklearnCompatMixin):
 
             self._X_train = X_combined
             self._y_train = y_combined
+            self._sample_weight = validate_sample_weight(w_combined, n_new)
 
             return self
 
@@ -1565,6 +1724,7 @@ class MultiOutputSymbolicRegressor(_SklearnCompatMixin):
         self,
         X: jnp.ndarray,
         y: jnp.ndarray,
+        sample_weight: jnp.ndarray | None = None,
     ) -> MultiOutputSymbolicRegressor:
         """
         Fit one symbolic regressor per output column.
@@ -1576,6 +1736,10 @@ class MultiOutputSymbolicRegressor(_SklearnCompatMixin):
         y : array-like of shape (n_samples, n_outputs)
             Target matrix.  Must be 2-D; for single-output problems use
             ``SymbolicRegressor`` directly.
+        sample_weight : array-like of shape (n_samples,), optional
+            Per-sample weights, shared by every output.  Weights that differ
+            per output are not supported here -- fit separate
+            :class:`SymbolicRegressor` instances for that.
 
         Returns
         -------
@@ -1585,8 +1749,9 @@ class MultiOutputSymbolicRegressor(_SklearnCompatMixin):
         Raises
         ------
         ValueError
-            If ``y`` is not 2-D, if shapes are inconsistent, or if
-            ``target_names`` length does not match the number of columns.
+            If ``y`` is not 2-D, if shapes are inconsistent, if
+            ``target_names`` length does not match the number of columns, or
+            if ``sample_weight`` is invalid.
         """
         X = jnp.atleast_2d(jnp.asarray(X))
         y = jnp.asarray(y)
@@ -1620,10 +1785,12 @@ class MultiOutputSymbolicRegressor(_SklearnCompatMixin):
             else [f"y{i}" for i in range(n_outputs)]
         )
 
+        weights = validate_sample_weight(sample_weight, X.shape[0])
+
         self._estimators = []
         for j in range(n_outputs):
             est = _clone_estimator(self.estimator)
-            est.fit(X, y[:, j])
+            est.fit(X, y[:, j], sample_weight=weights)
             self._estimators.append(est)
 
         self._is_fitted = True
@@ -1801,6 +1968,7 @@ def fit_symbolic(
     include_ratios: bool = False,
     strategy: str = "greedy_forward",
     information_criterion: str = "bic",
+    sample_weight: jnp.ndarray | None = None,
 ) -> SymbolicRegressor:
     """
     Convenience function for quick symbolic regression.
@@ -1825,11 +1993,18 @@ def fit_symbolic(
         Selection strategy.
     information_criterion : str
         Information criterion.
+    sample_weight : array-like of shape (n_samples,), optional
+        Per-sample weights; see :meth:`SymbolicRegressor.fit`.
 
     Returns
     -------
     model : SymbolicRegressor
         Fitted model.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
 
     Examples
     --------
@@ -1857,4 +2032,4 @@ def fit_symbolic(
         information_criterion=information_criterion,
     )
 
-    return model.fit(X, y)
+    return model.fit(X, y, sample_weight=sample_weight)

--- a/src/jaxsr/selection.py
+++ b/src/jaxsr/selection.py
@@ -22,6 +22,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from .metrics import compute_classification_ic, compute_information_criterion
+from .utils import validate_sample_weight, whiten
 
 # =============================================================================
 # Data Structures
@@ -128,9 +129,10 @@ class SelectionPath:
 def fit_ols(
     Phi: jnp.ndarray,
     y: jnp.ndarray,
+    sample_weight: jnp.ndarray | None = None,
 ) -> tuple[jnp.ndarray, float]:
     """
-    Fit ordinary least squares.
+    Fit ordinary (or weighted) least squares.
 
     Parameters
     ----------
@@ -138,17 +140,29 @@ def fit_ols(
         Design matrix of shape (n_samples, n_features).
     y : jnp.ndarray
         Target vector.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights of shape ``(n_samples,)``.  When given, minimises
+        ``sum_i w_i (y_i - phi_i @ c)^2`` and returns the weighted MSE.
+        Weights are normalised to sum to ``n_samples`` first, so the returned
+        MSE stays on the same scale as the unweighted one.
 
     Returns
     -------
     coefficients : jnp.ndarray
         Fitted coefficients.
     mse : float
-        Mean squared error.
+        (Weighted) mean squared error.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` has the wrong length or contains negative or
+        non-finite values.
     """
-    coeffs, residuals, rank, s = jnp.linalg.lstsq(Phi, y, rcond=None)
-    y_pred = Phi @ coeffs
-    mse = float(jnp.mean((y - y_pred) ** 2))
+    w = validate_sample_weight(sample_weight, Phi.shape[0])
+    Phi_w, y_w = whiten(Phi, w), whiten(y, w)
+    coeffs, residuals, rank, s = jnp.linalg.lstsq(Phi_w, y_w, rcond=None)
+    mse = float(jnp.mean((y_w - Phi_w @ coeffs) ** 2))
     return coeffs, mse
 
 
@@ -156,6 +170,7 @@ def fit_ridge(
     Phi: jnp.ndarray,
     y: jnp.ndarray,
     alpha: float,
+    sample_weight: jnp.ndarray | None = None,
 ) -> tuple[jnp.ndarray, float]:
     """
     Fit ridge regression (L2 regularized OLS).
@@ -170,23 +185,33 @@ def fit_ridge(
         Target vector.
     alpha : float
         L2 regularization strength.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights of shape ``(n_samples,)``.  When given, the data
+        term becomes ``sum_i w_i (y_i - phi_i @ c)^2``.
 
     Returns
     -------
     coefficients : jnp.ndarray
         Fitted coefficients.
     mse : float
-        Mean squared error (without regularization term).
+        (Weighted) mean squared error (without regularization term).
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` has the wrong length or contains negative or
+        non-finite values.
     """
-    n_samples, n_features = Phi.shape
+    w = validate_sample_weight(sample_weight, Phi.shape[0])
+    Phi_w, y_w = whiten(Phi, w), whiten(y, w)
+    n_samples, n_features = Phi_w.shape
 
     # Ridge solution: (Phi^T Phi + alpha*I)^{-1} Phi^T y
-    PhiTPhi = Phi.T @ Phi
+    PhiTPhi = Phi_w.T @ Phi_w
     regularized = PhiTPhi + alpha * jnp.eye(n_features)
-    coeffs = jnp.linalg.solve(regularized, Phi.T @ y)
+    coeffs = jnp.linalg.solve(regularized, Phi_w.T @ y_w)
 
-    y_pred = Phi @ coeffs
-    mse = float(jnp.mean((y - y_pred) ** 2))
+    mse = float(jnp.mean((y_w - Phi_w @ coeffs) ** 2))
     return coeffs, mse
 
 
@@ -389,14 +414,28 @@ def _fit_subset_parametric(
     param_optimizer: str = "scipy",
     param_optimization_budget: int = 50,
     _param_cache: dict | None = None,
+    sqrt_sample_weight: jnp.ndarray | None = None,
 ) -> SelectionResult:
-    """Profile-likelihood fit: optimise nonlinear params, solve OLS inside."""
+    """Profile-likelihood fit: optimise nonlinear params, solve OLS inside.
+
+    ``Phi`` and ``y`` are expected to be *already whitened* by the caller when
+    sample weights are in play; ``sqrt_sample_weight`` is the same
+    ``sqrt(w)`` factor, needed here because parametric columns are rebuilt
+    from the raw ``X`` at every trial value and must be whitened to match.
+    """
     import re
 
     from scipy.optimize import minimize as sp_minimize
     from scipy.optimize import minimize_scalar
 
     param_index_set = {p.basis_index for p in parametric_in_subset}
+
+    def _parametric_column(pi, params):
+        """Evaluate a parametric basis at ``X``, whitened to match ``Phi``."""
+        col = pi.func(X, **params)
+        if sqrt_sample_weight is None:
+            return col
+        return col * sqrt_sample_weight
 
     # ---- cache check ----
     cache_key = tuple(sorted(indices_list))
@@ -409,7 +448,7 @@ def _fit_subset_parametric(
             for idx in indices_list:
                 if idx in param_index_set:
                     pi = next(p for p in parametric_in_subset if p.basis_index == idx)
-                    cols.append(pi.func(X, **all_pv[idx]))
+                    cols.append(_parametric_column(pi, all_pv[idx]))
                 else:
                     cols.append(Phi[:, idx])
             return jnp.column_stack(cols)
@@ -531,7 +570,7 @@ def _fit_subset_parametric(
     for idx in indices_list:
         if idx in param_index_set:
             pi = next(p for p in parametric_in_subset if p.basis_index == idx)
-            cols.append(pi.func(X, **best_params[idx]))
+            cols.append(_parametric_column(pi, best_params[idx]))
         else:
             cols.append(Phi[:, idx])
     Phi_subset = jnp.column_stack(cols)
@@ -584,6 +623,7 @@ def fit_subset(
     param_optimizer: str = "scipy",
     param_optimization_budget: int = 50,
     _param_cache: dict | None = None,
+    sqrt_sample_weight: jnp.ndarray | None = None,
 ) -> SelectionResult:
     """
     Fit model using only selected basis functions.
@@ -612,6 +652,10 @@ def fit_subset(
         Number of optuna trials (ignored for scipy).
     _param_cache : dict, optional
         Cache for optimised parametric parameter values.
+    sqrt_sample_weight : jnp.ndarray, optional
+        ``sqrt(sample_weight)`` already applied to ``Phi`` and ``y`` by the
+        caller.  Only needed for parametric libraries, whose columns are
+        rebuilt from the raw ``X`` and must be whitened to match.
 
     Returns
     -------
@@ -640,6 +684,7 @@ def fit_subset(
                 param_optimizer,
                 param_optimization_budget,
                 _param_cache,
+                sqrt_sample_weight,
             )
 
     Phi_subset = Phi[:, indices]
@@ -686,6 +731,7 @@ def greedy_forward_selection(
     param_optimizer: str = "scipy",
     param_optimization_budget: int = 50,
     constraint_scorer=None,
+    sample_weight: jnp.ndarray | None = None,
 ) -> SelectionPath:
     """
     Greedy forward stepwise selection.
@@ -713,12 +759,25 @@ def greedy_forward_selection(
         Indices of candidate basis functions to consider.
     regularization : float, optional
         L2 regularization strength (ridge penalty).
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.  Every candidate model is fitted by weighted least
+        squares and scored by the weighted MSE, so the weights steer term
+        selection, not just the final coefficients.
 
     Returns
     -------
     path : SelectionPath
         Selection path with all intermediate results.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
+    _w = validate_sample_weight(sample_weight, Phi.shape[0])
+    Phi, y = whiten(Phi, _w), whiten(y, _w)
+    _sqrt_w = None if _w is None else jnp.sqrt(_w)
+
     n_basis = Phi.shape[1]
 
     if candidate_indices is None:
@@ -740,6 +799,7 @@ def greedy_forward_selection(
         "param_optimizer": param_optimizer,
         "param_optimization_budget": param_optimization_budget,
         "_param_cache": _param_cache,
+        "sqrt_sample_weight": _sqrt_w,
     }
 
     # Precompute Gram matrix when no parametric basis functions are present
@@ -858,6 +918,7 @@ def greedy_backward_elimination(
     param_optimizer: str = "scipy",
     param_optimization_budget: int = 50,
     constraint_scorer=None,
+    sample_weight: jnp.ndarray | None = None,
 ) -> SelectionPath:
     """
     Greedy backward elimination.
@@ -881,12 +942,24 @@ def greedy_backward_elimination(
         Criterion for selection.
     start_indices : list of int, optional
         Starting indices. If None, uses all basis functions.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights; every candidate model is fitted and scored by
+        weighted least squares.
 
     Returns
     -------
     path : SelectionPath
         Selection path.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
+    _w = validate_sample_weight(sample_weight, Phi.shape[0])
+    Phi, y = whiten(Phi, _w), whiten(y, _w)
+    _sqrt_w = None if _w is None else jnp.sqrt(_w)
+
     n_basis = Phi.shape[1]
 
     if start_indices is None:
@@ -905,6 +978,7 @@ def greedy_backward_elimination(
         "param_optimizer": param_optimizer,
         "param_optimization_budget": param_optimization_budget,
         "_param_cache": _param_cache,
+        "sqrt_sample_weight": _sqrt_w,
     }
 
     # Precompute Gram matrix when no parametric basis functions are present
@@ -992,6 +1066,7 @@ def exhaustive_search(
     param_optimizer: str = "scipy",
     param_optimization_budget: int = 50,
     constraint_scorer=None,
+    sample_weight: jnp.ndarray | None = None,
 ) -> SelectionPath:
     """
     Exhaustive search over all combinations.
@@ -1019,6 +1094,10 @@ def exhaustive_search(
     regularization : float, optional
         L2 regularization strength (ridge penalty).
 
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights; every subset is fitted and scored by weighted
+        least squares.
+
     Returns
     -------
     path : SelectionPath
@@ -1027,8 +1106,13 @@ def exhaustive_search(
     Raises
     ------
     ValueError
-        If too many combinations would be evaluated.
+        If too many combinations would be evaluated, or if ``sample_weight``
+        is invalid.
     """
+    _w = validate_sample_weight(sample_weight, Phi.shape[0])
+    Phi, y = whiten(Phi, _w), whiten(y, _w)
+    _sqrt_w = None if _w is None else jnp.sqrt(_w)
+
     if candidate_indices is None:
         candidate_indices = list(range(Phi.shape[1]))
 
@@ -1050,6 +1134,7 @@ def exhaustive_search(
         "param_optimizer": param_optimizer,
         "param_optimization_budget": param_optimization_budget,
         "_param_cache": _param_cache,
+        "sqrt_sample_weight": _sqrt_w,
     }
 
     # Precompute Gram matrix when no parametric basis functions are present
@@ -1181,6 +1266,7 @@ def lasso_path_selection(
     param_optimizer: str = "scipy",
     param_optimization_budget: int = 50,
     constraint_scorer=None,
+    sample_weight: jnp.ndarray | None = None,
 ) -> SelectionPath:
     """
     LASSO path screening for variable selection.
@@ -1206,12 +1292,25 @@ def lasso_path_selection(
         Number of regularization values.
     alpha_min_ratio : float
         Ratio of min to max alpha.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.  The screening LASSO and the OLS refit of each
+        active set both run on the weighted problem.
 
     Returns
     -------
     path : SelectionPath
         Selection path.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
+    _w = validate_sample_weight(sample_weight, Phi.shape[0])
+    _Phi_raw, _y_raw = Phi, y  # kept unwhitened for the greedy fallback below
+    Phi, y = whiten(Phi, _w), whiten(y, _w)
+    _sqrt_w = None if _w is None else jnp.sqrt(_w)
+
     n_samples, n_features = Phi.shape
 
     # Standardize features
@@ -1247,6 +1346,7 @@ def lasso_path_selection(
         "param_optimizer": param_optimizer,
         "param_optimization_budget": param_optimization_budget,
         "_param_cache": _param_cache,
+        "sqrt_sample_weight": _sqrt_w,
     }
 
     # Precompute Gram matrix when no parametric basis functions are present
@@ -1297,10 +1397,12 @@ def lasso_path_selection(
             best_index = len(results) - 1
 
     if not results:
-        # Fallback to greedy forward if LASSO finds nothing
+        # Fallback to greedy forward if LASSO finds nothing.  Pass the
+        # unwhitened matrices plus the weights -- greedy_forward_selection
+        # whitens for itself, and whitening twice would square the weights.
         return greedy_forward_selection(
-            Phi,
-            y,
+            _Phi_raw,
+            _y_raw,
             basis_names,
             complexities,
             max_terms,
@@ -1311,6 +1413,7 @@ def lasso_path_selection(
             param_optimizer=param_optimizer,
             param_optimization_budget=param_optimization_budget,
             constraint_scorer=constraint_scorer,
+            sample_weight=sample_weight,
         )
 
     return SelectionPath(
@@ -1497,6 +1600,7 @@ def select_features(
     strategy: str = "greedy_forward",
     max_terms: int = 5,
     information_criterion: str = "bic",
+    sample_weight: jnp.ndarray | None = None,
     **kwargs,
 ) -> SelectionPath:
     """
@@ -1518,6 +1622,11 @@ def select_features(
         Maximum number of terms.
     information_criterion : str
         Information criterion for model selection.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights of shape ``(n_samples,)``.  Pass ``Phi`` and ``y``
+        unweighted -- the strategy whitens them internally.  Every strategy
+        supports weights, so selection, coefficients and the reported MSE are
+        all consistent with the weighted objective.
     **kwargs
         Additional arguments for specific strategies.
 
@@ -1525,6 +1634,11 @@ def select_features(
     -------
     path : SelectionPath
         Selection results.
+
+    Raises
+    ------
+    ValueError
+        If ``strategy`` is unknown or ``sample_weight`` is invalid.
     """
     strategies = {
         "greedy_forward": greedy_forward_selection,
@@ -1543,6 +1657,7 @@ def select_features(
         complexities=complexities,
         max_terms=max_terms,
         information_criterion=information_criterion,
+        sample_weight=sample_weight,
         **kwargs,
     )
 

--- a/src/jaxsr/skill/SKILL.md
+++ b/src/jaxsr/skill/SKILL.md
@@ -386,6 +386,12 @@ See `guides/rsm.md` for RSM designs, canonical analysis, and optimization.
 
 See `guides/active-learning.md` for acquisition functions and adaptive sampling.
 
+### "My measurements aren't equally precise"
+
+See `guides/sample-weights.md` for `sample_weight`: weighted least squares applied
+consistently through selection, information criteria, constraints and uncertainty,
+plus the effective-sample-size policy and why row duplication is not a substitute.
+
 ### "One expression isn't enough / the signal is a sum of many effects"
 
 See `guides/additive.md` for boosting-style additive symbolic regression

--- a/src/jaxsr/skill/guides/model-fitting.md
+++ b/src/jaxsr/skill/guides/model-fitting.md
@@ -266,3 +266,15 @@ y_pred = predict_fn(X_numpy)
 model.save("model.json")
 loaded = SymbolicRegressor.load("model.json")
 ```
+
+## Unequal Measurement Precision
+
+If your observations differ in precision, pass `sample_weight` to `fit()`:
+
+```python
+model.fit(X, y, sample_weight=1.0 / variances)
+```
+
+Weights are honoured by term selection, the reported MSE and information criteria,
+constraint refitting and every uncertainty method — not just the final coefficients.
+See `guides/sample-weights.md`.

--- a/src/jaxsr/skill/guides/sample-weights.md
+++ b/src/jaxsr/skill/guides/sample-weights.md
@@ -1,0 +1,134 @@
+# Sample Weights
+
+Use `sample_weight` when your observations are **not equally trustworthy**: different
+measurement precisions, replicate-derived variances, or regions of the design space that
+carry little information about the quantity you care about.
+
+```python
+model = SymbolicRegressor(basis_library=library, max_terms=4)
+model.fit(X, y, sample_weight=1.0 / variances)
+```
+
+## What weights mean
+
+Observation `i` is modelled as having variance `sigma^2 / w_i`, so the fit minimises
+
+```
+sum_i  w_i * (y_i - f(x_i))^2
+```
+
+A point with twice the weight is treated as twice as precise — equivalently, as carrying
+twice the information.
+
+**Only ratios matter.** Weights are normalised to average 1 internally, so `w`, `2*w` and
+`w/1000` give the identical model, MSE and information criteria. You never have to worry
+about what units your weights are in.
+
+## Where the weights are used
+
+Weights are not a cosmetic adjustment to the final coefficients — they run through the
+whole pipeline:
+
+| Stage | Effect |
+|-------|--------|
+| Term selection (all four strategies) | Every candidate subset is fitted and scored on the weighted objective |
+| `model.metrics_["mse"]` | Weighted MSE, `sum_i w_i r_i^2 / n` |
+| AIC / BIC / AICc | Computed from the weighted MSE (see effective sample size below) |
+| `model.metrics_["r2"]`, `model.score()` | Weighted R², about the weighted mean of `y` |
+| Term pruning (`prune_tol`) | Contributions measured on the weighted design matrix |
+| Constraint refitting | Least-squares term weighted; the constraints themselves are not |
+| `sigma_`, `covariance_matrix_`, `coefficient_intervals()` | Weighted `s^2 (Phi^T W Phi)^{-1}` |
+| `predict_interval()`, `confidence_band()` | Weighted leverages |
+| `bootstrap_coefficients()`, `bootstrap_predict()` | Residuals resampled in whitened space, refit by WLS |
+| `bootstrap_model_selection()` | Weights follow their rows into each resample |
+| `anova()` | Weighted sums of squares, about the weighted mean |
+| `cross_validate()` | Weights follow their rows into the folds |
+| `predict_conformal(method="jackknife+")` | Weighted leverages and whitened LOO residuals |
+
+## Effective sample size
+
+The `n` used by AIC/BIC/AICc stays the **nominal** number of observations. Weighting
+describes how much you trust each measurement; it does not create or destroy
+measurements.
+
+This is also why **duplicating rows is not a valid way to emulate weights** — duplication
+inflates `n`, and `k*log(n)` in BIC shifts with it, so the comparison between models
+changes for a reason that has nothing to do with the data.
+
+When most of the weight sits on a few rows, the nominal `n` overstates how much
+information the model comparison rests on. Check:
+
+```python
+model.effective_sample_size_   # Kish ESS: (sum w)^2 / sum w^2
+```
+
+For 200 points where half carry weight ~0, this returns ~100. Treat that, not `n`, as
+your intuition for how strong the evidence is.
+
+## Recipes
+
+### Known measurement variances
+
+```python
+model.fit(X, y, sample_weight=1.0 / variances)
+```
+
+### Replicate means
+
+If `y_i` is the mean of `n_i` replicates with common noise variance, its variance is
+`sigma^2 / n_i`, so the weight is the replicate count:
+
+```python
+model.fit(X_means, y_means, sample_weight=replicate_counts)
+```
+
+### A smooth taper instead of a hard threshold
+
+Rows where a derived quantity is near zero carry little information about it. Rather than
+dropping them below a cutoff — which discards partially-informative rows and puts a step
+where a taper belongs — down-weight them continuously:
+
+```python
+# information about the slope scales with |y_x|; taper smoothly near zero
+w = y_x**2 / (y_x**2 + eps**2)
+model.fit(X, y_ratio, sample_weight=w)
+```
+
+Pick `eps` on the scale of the noise in `y_x`, not as a hard "keep/drop" boundary.
+
+### Excluding a row entirely
+
+A weight of exactly `0` removes a row from the fit but keeps it in `n`. If you mean to
+drop the observation, drop it from `X` and `y` instead — that also corrects `n` and every
+criterion computed from it.
+
+## Interpreting weighted intervals
+
+For a weighted fit, `sigma_` is the noise level of a **unit-weight** observation, and
+`predict_interval()` returns the interval for a new observation of unit weight — one as
+precise as an average training point. If the new observation has a known precision
+`w_new`, scale the half-width by `1 / sqrt(w_new)`.
+
+## Validation
+
+Bad weights are rejected up front rather than silently absorbed:
+
+- wrong length → `ValueError`
+- negative entries → `ValueError`
+- `NaN` / `inf` → `ValueError`
+- all zeros → `ValueError`
+
+## Not weighted
+
+- `conformal_predict_split()` — its coverage comes from exchangeability of the
+  user-supplied calibration residuals, not from the fit. With unequal-precision
+  calibration points the interval stays valid but is uninformatively wide for the precise
+  ones. Use `method="jackknife+"` for a weight-aware interval.
+- `SymbolicClassifier` — classification weights are not implemented.
+- `max_error` in `compute_all_metrics()` — a maximum has no weighted analogue; it is
+  reported over the rows with non-zero weight.
+
+## See also
+
+- `guides/uncertainty.md` — interval methods and when to use each
+- `guides/model-fitting.md` — selection strategies and criteria

--- a/src/jaxsr/skill/guides/uncertainty.md
+++ b/src/jaxsr/skill/guides/uncertainty.md
@@ -255,3 +255,11 @@ print(f"BMA width:      {np.mean(bma_hi - bma_lo):.4f}")
 print(f"Conformal width: {np.mean(conf_hi - conf_lo):.4f}")
 print(f"Bootstrap width: {np.mean(boot['upper'] - boot['lower']):.4f}")
 ```
+
+## Weighted Fits
+
+When the model was fitted with `sample_weight`, all of the intervals above use the
+weighted covariance `s^2 (Phi^T W Phi)^{-1}` and weighted leverages, and `sigma_` is the
+noise level of a *unit-weight* observation. The one exception is split conformal
+prediction, whose calibration set is treated as unweighted. See
+`guides/sample-weights.md`.

--- a/src/jaxsr/uncertainty.py
+++ b/src/jaxsr/uncertainty.py
@@ -18,6 +18,8 @@ import jax.numpy as jnp
 import numpy as np
 from scipy import stats
 
+from .utils import validate_sample_weight, weighted_mean, whiten
+
 if TYPE_CHECKING:
     from .regressor import SymbolicRegressor
 
@@ -31,6 +33,7 @@ def compute_unbiased_variance(
     Phi: jnp.ndarray,
     y: jnp.ndarray,
     coefficients: jnp.ndarray,
+    sample_weight: jnp.ndarray | None = None,
 ) -> float:
     """
     Compute unbiased noise variance estimate: s^2 = SSR / (n - p).
@@ -43,14 +46,24 @@ def compute_unbiased_variance(
         Target values of shape (n_samples,).
     coefficients : jnp.ndarray
         Fitted coefficients of shape (n_features,).
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.  The sum of squares becomes
+        ``sum_i w_i r_i^2``, so the estimate is the variance of a
+        *unit-weight* observation under the model ``var(y_i) = sigma^2 / w_i``.
 
     Returns
     -------
     sigma_sq : float
         Unbiased variance estimate.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
     n, p = Phi.shape
-    residuals = y - Phi @ coefficients
+    w = validate_sample_weight(sample_weight, n)
+    residuals = whiten(y - Phi @ coefficients, w)
     ssr = float(jnp.sum(residuals**2))
     dof = n - p
     if dof <= 0:
@@ -64,9 +77,10 @@ def compute_unbiased_variance(
 def compute_coeff_covariance(
     Phi: jnp.ndarray,
     sigma_sq: float,
+    sample_weight: jnp.ndarray | None = None,
 ) -> jnp.ndarray:
     """
-    Compute coefficient covariance matrix: Cov(beta) = sigma^2 * (Phi^T Phi)^{-1}.
+    Compute coefficient covariance matrix: Cov(beta) = sigma^2 * (Phi^T W Phi)^{-1}.
 
     Uses SVD for numerical stability.
 
@@ -76,15 +90,25 @@ def compute_coeff_covariance(
         Design matrix of shape (n_samples, n_features).
     sigma_sq : float
         Unbiased noise variance estimate.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights forming the diagonal of ``W``.  ``None`` gives the
+        ordinary ``sigma^2 (Phi^T Phi)^{-1}``.
 
     Returns
     -------
     cov : jnp.ndarray
         Covariance matrix of shape (n_features, n_features).
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
-    U, s, Vt = jnp.linalg.svd(Phi, full_matrices=False)
-    # (Phi^T Phi)^{-1} = V @ diag(1/s^2) @ V^T
-    rcond = jnp.finfo(Phi.dtype).eps * max(Phi.shape)
+    w = validate_sample_weight(sample_weight, Phi.shape[0])
+    Phi_w = whiten(Phi, w)
+    U, s, Vt = jnp.linalg.svd(Phi_w, full_matrices=False)
+    # (Phi^T W Phi)^{-1} = V @ diag(1/s^2) @ V^T for the whitened Phi
+    rcond = jnp.finfo(Phi_w.dtype).eps * max(Phi_w.shape)
     cutoff = rcond * jnp.max(s)
     s_inv_sq = jnp.where(s > cutoff, 1.0 / (s**2), 0.0)
     PhiTPhiInv = Vt.T @ jnp.diag(s_inv_sq) @ Vt
@@ -97,6 +121,7 @@ def coefficient_intervals(
     coefficients: jnp.ndarray,
     names: list[str],
     alpha: float = 0.05,
+    sample_weight: jnp.ndarray | None = None,
 ) -> dict[str, tuple[float, float, float, float]]:
     """
     Compute t-based confidence intervals for each coefficient.
@@ -113,13 +138,24 @@ def coefficient_intervals(
         Names of basis functions.
     alpha : float
         Significance level (default 0.05 for 95% CIs).
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights used for the fit.  Standard errors then come from
+        the weighted covariance ``s^2 (Phi^T W Phi)^{-1}``; passing ``None``
+        for a weighted fit understates the uncertainty of coefficients that
+        rest mostly on down-weighted rows.
 
     Returns
     -------
     intervals : dict
         {name: (estimate, lower, upper, se)} for each coefficient.
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
     n, p = Phi.shape
+    w = validate_sample_weight(sample_weight, n)
     dof = n - p
     if dof <= 0:
         warnings.warn("Not enough degrees of freedom for coefficient intervals.", stacklevel=2)
@@ -128,8 +164,8 @@ def coefficient_intervals(
             for name, coef in zip(names, coefficients, strict=False)
         }
 
-    sigma_sq = compute_unbiased_variance(Phi, y, coefficients)
-    cov = compute_coeff_covariance(Phi, sigma_sq)
+    sigma_sq = compute_unbiased_variance(Phi, y, coefficients, w)
+    cov = compute_coeff_covariance(Phi, sigma_sq, w)
     se = jnp.sqrt(jnp.diag(cov))
 
     t_crit = stats.t.ppf(1 - alpha / 2, dof)
@@ -151,6 +187,7 @@ def prediction_interval(
     coefficients: jnp.ndarray,
     Phi_new: jnp.ndarray,
     alpha: float = 0.05,
+    sample_weight: jnp.ndarray | None = None,
 ) -> dict[str, jnp.ndarray]:
     """
     Compute prediction and confidence intervals for new observations.
@@ -170,6 +207,10 @@ def prediction_interval(
         Design matrix for new points of shape (n_new, p).
     alpha : float
         Significance level (default 0.05 for 95% intervals).
+    sample_weight : jnp.ndarray, optional
+        Weights of the *training* rows, of shape ``(n_train,)``.  ``Phi_new``
+        is never weighted: the interval it produces is for a new observation
+        of unit weight, i.e. one as precise as an average training point.
 
     Returns
     -------
@@ -180,8 +221,14 @@ def prediction_interval(
         - "conf_lower", "conf_upper": confidence band bounds
         - "pred_se": prediction standard error
         - "conf_se": confidence standard error (mean response)
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
     n, p = Phi_train.shape
+    w = validate_sample_weight(sample_weight, n)
     dof = n - p
     if dof <= 0:
         y_pred = Phi_new @ coefficients
@@ -196,12 +243,13 @@ def prediction_interval(
             "conf_se": nan_arr,
         }
 
-    sigma_sq = compute_unbiased_variance(Phi_train, y_train, coefficients)
+    sigma_sq = compute_unbiased_variance(Phi_train, y_train, coefficients, w)
     sigma = jnp.sqrt(sigma_sq)
 
-    # Compute (Phi^T Phi)^{-1} via SVD
-    U, s, Vt = jnp.linalg.svd(Phi_train, full_matrices=False)
-    rcond = jnp.finfo(Phi_train.dtype).eps * max(Phi_train.shape)
+    # Compute (Phi^T W Phi)^{-1} via SVD of the whitened design matrix
+    Phi_train_w = whiten(Phi_train, w)
+    U, s, Vt = jnp.linalg.svd(Phi_train_w, full_matrices=False)
+    rcond = jnp.finfo(Phi_train_w.dtype).eps * max(Phi_train_w.shape)
     cutoff = rcond * jnp.max(s)
     s_inv_sq = jnp.where(s > cutoff, 1.0 / (s**2), 0.0)
     PhiTPhiInv = Vt.T @ jnp.diag(s_inv_sq) @ Vt
@@ -492,6 +540,15 @@ def conformal_predict_split(
         - "lower": lower interval bound
         - "upper": upper interval bound
         - "quantile": the conformal quantile used
+
+    Notes
+    -----
+    The calibration set is treated as unweighted, even when ``model`` was
+    fitted with ``sample_weight``: coverage here comes from exchangeability of
+    the calibration residuals, not from the fit.  If the calibration points
+    have unequal precision, the resulting interval is a valid but
+    uninformatively wide one for the precise points.  For a weight-aware
+    interval use ``method="jackknife+"``, which reuses the training weights.
     """
     model._check_is_fitted()
     X_cal = jnp.atleast_2d(jnp.asarray(X_cal))
@@ -547,6 +604,20 @@ def conformal_predict_jackknife_plus(
         - "y_pred": point predictions
         - "lower": lower interval bound
         - "upper": upper interval bound
+
+    Raises
+    ------
+    ValueError
+        If the model has no stored training data.
+
+    Notes
+    -----
+    For a weighted fit the leverages are the weighted-least-squares ones and
+    the nonconformity scores are the whitened LOO residuals
+    ``sqrt(w_i) |r_i| / (1 - h_ii)``, which are exchangeable under the model
+    ``var(y_i) = sigma^2 / w_i``.  The resulting interval is therefore for a
+    new observation of *unit* weight; scale it by ``1 / sqrt(w_new)`` if the
+    new point has a known precision of its own.
     """
     model._check_is_fitted()
     X_new = jnp.atleast_2d(jnp.asarray(X_new))
@@ -556,20 +627,21 @@ def conformal_predict_jackknife_plus(
 
     X_train = model._X_train
     y_train = model._y_train
+    weights = getattr(model, "_sample_weight", None)
     n = len(y_train)
 
     # Compute design matrix for training data
     Phi_train = model.basis_library.evaluate_subset(X_train, model._result.selected_indices)
     coefficients = model._result.coefficients
 
-    # Compute leverage (hat matrix diagonal)
-    Phi_pinv = jnp.linalg.pinv(Phi_train)
-    H = Phi_train @ Phi_pinv
-    h_diag = jnp.diag(H)
+    # Compute leverage (hat matrix diagonal) of the whitened problem:
+    # h_ii = w_i * phi_i^T (Phi^T W Phi)^-1 phi_i
+    Phi_w = whiten(Phi_train, weights)
+    h_diag = jnp.sum(Phi_w * jnp.linalg.pinv(Phi_w).T, axis=1)
 
-    # LOO residuals: e_i / (1 - h_ii)
+    # LOO residuals: e_i / (1 - h_ii), whitened so they are exchangeable
     y_pred_train = Phi_train @ coefficients
-    residuals = y_train - y_pred_train
+    residuals = whiten(y_train - y_pred_train, weights)
     loo_residuals = residuals / (1 - h_diag + 1e-10)
 
     # LOO predictions: y_hat_i^{-i} = y_i - e_i/(1-h_ii) ... wait,
@@ -638,6 +710,20 @@ def bootstrap_coefficients(
         - "lower": lower CI bound for each coefficient
         - "upper": upper CI bound for each coefficient
         - "names": coefficient names
+
+    Raises
+    ------
+    ValueError
+        If the model has no stored training data.
+
+    Notes
+    -----
+    Weights from :meth:`~jaxsr.SymbolicRegressor.fit` are honoured
+    automatically.  Raw residuals of a weighted fit are not exchangeable --
+    a down-weighted row is *expected* to miss by more -- so resampling them
+    directly would leak that row's noise onto precise rows.  The resampling
+    therefore happens in whitened space, on ``sqrt(w_i) * r_i``, and each
+    bootstrap replicate is refit by weighted least squares.
     """
     model._check_is_fitted()
 
@@ -646,21 +732,27 @@ def bootstrap_coefficients(
 
     Phi_train = model.basis_library.evaluate_subset(model._X_train, model._result.selected_indices)
     y_train = model._y_train
+    weights = getattr(model, "_sample_weight", None)
     coefficients = model._result.coefficients
     y_hat = Phi_train @ coefficients
-    residuals = y_train - y_hat
+
+    # Work in whitened space: OLS there is exactly WLS here, and the whitened
+    # residuals are homoscedastic, so they can be resampled across rows.
+    Phi_w = whiten(Phi_train, weights)
+    residuals_w = whiten(y_train - y_hat, weights)
+    y_hat_w = whiten(y_hat, weights)
 
     rng = np.random.RandomState(seed)
     n = len(y_train)
 
     # Generate all bootstrap y* at once
     boot_indices = rng.randint(0, n, size=(n_bootstrap, n))
-    boot_residuals = np.array(residuals)[boot_indices]  # (n_bootstrap, n)
-    y_star = np.array(y_hat)[None, :] + boot_residuals  # (n_bootstrap, n)
+    boot_residuals = np.array(residuals_w)[boot_indices]  # (n_bootstrap, n)
+    y_star = np.array(y_hat_w)[None, :] + boot_residuals  # (n_bootstrap, n)
 
-    # Vectorized OLS: beta* = (Phi^T Phi)^{-1} Phi^T y*
+    # Vectorized WLS: beta* = (Phi_w^T Phi_w)^{-1} Phi_w^T y_w*
     # Pre-compute pseudo-inverse
-    Phi_np = np.array(Phi_train)
+    Phi_np = np.array(Phi_w)
     PhiTPhiInv_PhiT = np.linalg.pinv(Phi_np)  # (p, n)
 
     # All bootstrap coefficients at once
@@ -743,6 +835,7 @@ def bootstrap_model_selection(
     y: jnp.ndarray,
     n_bootstrap: int = 100,
     seed: int | None = None,
+    sample_weight: jnp.ndarray | None = None,
 ) -> dict[str, Any]:
     """
     Pairs bootstrap for model selection stability.
@@ -762,6 +855,11 @@ def bootstrap_model_selection(
         Number of bootstrap samples.
     seed : int, optional
         Random seed.
+    sample_weight : jnp.ndarray, optional
+        Per-sample weights.  Each weight follows its row into the resample,
+        so a replicate that happens to draw many down-weighted rows is fitted
+        as the thin evidence it is.  Defaults to the weights ``model`` was
+        fitted with when ``X`` and ``y`` are that same training set.
 
     Returns
     -------
@@ -770,10 +868,27 @@ def bootstrap_model_selection(
         - "feature_frequencies": dict mapping feature name to selection frequency
         - "stability_score": fraction of bootstraps selecting the same features
         - "expressions": list of expressions found across bootstraps
+
+    Raises
+    ------
+    ValueError
+        If ``sample_weight`` is invalid.
     """
     X = jnp.atleast_2d(jnp.asarray(X))
     y = jnp.asarray(y).ravel()
     n = len(y)
+
+    if sample_weight is None and getattr(model, "_sample_weight", None) is not None:
+        if len(model._sample_weight) == n:
+            sample_weight = model._sample_weight
+        else:
+            warnings.warn(
+                "model was fitted with sample_weight but X/y here have a different "
+                "length, so the bootstrap runs unweighted. Pass sample_weight "
+                "explicitly to weight it.",
+                stacklevel=2,
+            )
+    weights = validate_sample_weight(sample_weight, n)
 
     rng = np.random.RandomState(seed)
 
@@ -786,6 +901,9 @@ def bootstrap_model_selection(
         boot_idx = rng.randint(0, n, size=n)
         X_boot = X[boot_idx]
         y_boot = y[boot_idx]
+        w_boot = None if weights is None else weights[boot_idx]
+        if w_boot is not None and float(jnp.sum(w_boot)) <= 0:
+            continue  # degenerate resample: every drawn row had zero weight
 
         # Clone model
         model_boot = model.__class__(
@@ -799,7 +917,7 @@ def bootstrap_model_selection(
             random_state=model.random_state,
         )
         try:
-            model_boot.fit(X_boot, y_boot)
+            model_boot.fit(X_boot, y_boot, sample_weight=w_boot)
             selected = set(model_boot.selected_features_)
             for feat in selected:
                 feature_counts[feat] = feature_counts.get(feat, 0) + 1
@@ -962,6 +1080,12 @@ def anova(
     The returned :pyclass:`AnovaResult` includes diagnostic warnings when
     these conditions are detected.
 
+    When the model was fitted with ``sample_weight``, every sum of squares is
+    the weighted one (``sum_i w_i r_i^2``) and the total is taken about the
+    weighted mean of ``y``, so the table decomposes the same quantity the fit
+    minimised.  Degrees of freedom stay nominal, matching the information
+    criteria.
+
     Examples
     --------
     >>> from jaxsr.uncertainty import anova
@@ -977,16 +1101,22 @@ def anova(
 
     X = model._X_train
     y = model._y_train
+    weights = getattr(model, "_sample_weight", None)
     n = len(y)
     selected = list(np.array(model._result.selected_indices))
     names = list(model._result.selected_names)
     p = len(selected)
 
+    # Everything below is computed on the whitened problem, so each sum of
+    # squares is the weighted one and reduces to the ordinary one when the
+    # model was fitted without weights.
+    y_w = whiten(y, weights)
+
     # Full model design matrix and residuals
     Phi_full = model.basis_library.evaluate_subset(X, selected)
     y_hat_full = Phi_full @ model._result.coefficients
-    ss_res_full = float(jnp.sum((y - y_hat_full) ** 2))
-    ss_tot = float(jnp.sum((y - jnp.mean(y)) ** 2))
+    ss_res_full = float(jnp.sum(whiten(y - y_hat_full, weights) ** 2))
+    ss_tot = float(jnp.sum(whiten(y - weighted_mean(y, weights), weights) ** 2))
     ss_model = ss_tot - ss_res_full
     df_res = n - p
     ms_res = ss_res_full / df_res if df_res > 0 else float("inf")
@@ -1014,9 +1144,9 @@ def anova(
         ss_prev = ss_tot  # residual SS of the "null" (intercept-free) model
         for k in range(p):
             subset = selected[: k + 1]
-            Phi_k = model.basis_library.evaluate_subset(X, subset)
-            beta_k = jnp.linalg.lstsq(Phi_k, y, rcond=None)[0]
-            ss_res_k = float(jnp.sum((y - Phi_k @ beta_k) ** 2))
+            Phi_k = whiten(model.basis_library.evaluate_subset(X, subset), weights)
+            beta_k = jnp.linalg.lstsq(Phi_k, y_w, rcond=None)[0]
+            ss_res_k = float(jnp.sum((y_w - Phi_k @ beta_k) ** 2))
             ss_term = ss_prev - ss_res_k  # extra SS explained by this term
             ss_term = max(ss_term, 0.0)
             ms_term = ss_term  # df = 1 per term
@@ -1042,9 +1172,9 @@ def anova(
                 # Only one term — its marginal SS is the whole model SS
                 ss_term = ss_model
             else:
-                Phi_mk = model.basis_library.evaluate_subset(X, subset_minus_k)
-                beta_mk = jnp.linalg.lstsq(Phi_mk, y, rcond=None)[0]
-                ss_res_mk = float(jnp.sum((y - Phi_mk @ beta_mk) ** 2))
+                Phi_mk = whiten(model.basis_library.evaluate_subset(X, subset_minus_k), weights)
+                beta_mk = jnp.linalg.lstsq(Phi_mk, y_w, rcond=None)[0]
+                ss_res_mk = float(jnp.sum((y_w - Phi_mk @ beta_mk) ** 2))
                 ss_term = ss_res_mk - ss_res_full
             ss_term = max(ss_term, 0.0)
             ms_term = ss_term

--- a/src/jaxsr/utils.py
+++ b/src/jaxsr/utils.py
@@ -352,6 +352,189 @@ def compute_residuals(
 
 
 # =============================================================================
+# Sample Weights
+# =============================================================================
+
+
+def validate_sample_weight(
+    sample_weight: Any,
+    n_samples: int,
+    name: str = "sample_weight",
+    normalize: bool = True,
+) -> jnp.ndarray | None:
+    """
+    Validate sample weights and normalise them to sum to ``n_samples``.
+
+    Weights encode the *relative* precision of each observation: an
+    observation with weight ``w`` is treated as having variance
+    ``sigma^2 / w``.  Only ratios matter, so the weights are rescaled to
+    average 1.  This is the convention that keeps the effective sample size
+    equal to ``n_samples`` and makes the fit invariant to the overall scale
+    of the weights -- ``w``, ``2 * w`` and ``w / 1000`` all give the same
+    model, the same MSE and the same information criteria.
+
+    Parameters
+    ----------
+    sample_weight : array-like or None
+        Per-sample weights of shape ``(n_samples,)``.  ``None`` is passed
+        through unchanged and means "all observations equally weighted".
+    n_samples : int
+        Expected number of samples.
+    name : str
+        Argument name to use in error messages.
+    normalize : bool
+        If True (default), rescale the weights to sum to ``n_samples`` and
+        reject an all-zero vector, which cannot define a fit.  Pass False when
+        the weights are a *fragment* that will be concatenated with others --
+        rescaling a fragment on its own would change its meaning relative to
+        the rest, and an all-zero fragment is perfectly legitimate.
+
+    Returns
+    -------
+    jnp.ndarray or None
+        Validated weights of shape ``(n_samples,)``, summing to ``n_samples``
+        when ``normalize`` is True, or ``None`` if ``sample_weight`` was
+        ``None``.
+
+    Raises
+    ------
+    ValueError
+        If the weights have the wrong length, are not 1-D after ravelling,
+        contain non-finite or negative entries, or (when ``normalize``) sum
+        to zero.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> w = validate_sample_weight(np.array([1e-3, 1e-3, 2e-3, 2e-3]), 4)
+    >>> float(w.sum())
+    4.0
+    """
+    if sample_weight is None:
+        return None
+
+    w = jnp.asarray(sample_weight, dtype=float).ravel()
+
+    if w.shape[0] != n_samples:
+        raise ValueError(f"{name} has {w.shape[0]} entries but there are {n_samples} samples.")
+
+    if not bool(jnp.all(jnp.isfinite(w))):
+        raise ValueError(f"{name} must be finite; got NaN or inf entries.")
+
+    if bool(jnp.any(w < 0)):
+        raise ValueError(f"{name} must be non-negative.")
+
+    if not normalize:
+        return w
+
+    total = float(jnp.sum(w))
+    if total <= 0:
+        raise ValueError(f"{name} must have a positive sum; got {total}.")
+
+    return w * (n_samples / total)
+
+
+def whiten(array: jnp.ndarray, sample_weight: jnp.ndarray | None) -> jnp.ndarray:
+    """
+    Scale rows of an array by ``sqrt(sample_weight)``.
+
+    Weighted least squares on ``(Phi, y)`` is ordinary least squares on the
+    whitened pair ``(whiten(Phi, w), whiten(y, w))``: both minimise
+    ``sum_i w_i (y_i - phi_i @ c)^2``.  With weights normalised by
+    :func:`validate_sample_weight`, the mean squared error of the whitened
+    residuals is exactly the weighted MSE ``sum_i w_i r_i^2 / n``, so every
+    downstream quantity -- information criteria, covariance matrices,
+    intervals -- follows from the unweighted code path unchanged.
+
+    Parameters
+    ----------
+    array : jnp.ndarray
+        1-D vector of shape ``(n_samples,)`` or 2-D matrix of shape
+        ``(n_samples, n_columns)``.
+    sample_weight : jnp.ndarray or None
+        Weights of shape ``(n_samples,)``.  ``None`` returns ``array``
+        unchanged.
+
+    Returns
+    -------
+    jnp.ndarray
+        The row-scaled array, with the same shape as ``array``.
+
+    Raises
+    ------
+    ValueError
+        If ``array`` is neither 1-D nor 2-D.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> [float(v) for v in whiten(jnp.array([1.0, 1.0]), jnp.array([4.0, 0.0]))]
+    [2.0, 0.0]
+    """
+    if sample_weight is None:
+        return array
+
+    sqrt_w = jnp.sqrt(sample_weight)
+    if array.ndim == 1:
+        return array * sqrt_w
+    if array.ndim == 2:
+        return array * sqrt_w[:, None]
+    raise ValueError(f"whiten expects a 1-D or 2-D array, got ndim={array.ndim}.")
+
+
+def weighted_mean(values: jnp.ndarray, sample_weight: jnp.ndarray | None) -> jnp.ndarray:
+    """
+    Weighted mean of ``values``, falling back to the plain mean.
+
+    Parameters
+    ----------
+    values : jnp.ndarray
+        Values of shape ``(n_samples,)``.
+    sample_weight : jnp.ndarray or None
+        Weights of shape ``(n_samples,)``.  ``None`` gives the plain mean.
+
+    Returns
+    -------
+    jnp.ndarray
+        Scalar weighted mean ``sum(w * v) / sum(w)``.
+    """
+    if sample_weight is None:
+        return jnp.mean(values)
+    return jnp.sum(sample_weight * values) / jnp.sum(sample_weight)
+
+
+def effective_sample_size(sample_weight: jnp.ndarray | None, n_samples: int) -> float:
+    """
+    Kish effective sample size ``(sum w)^2 / sum w^2``.
+
+    This is *reported* rather than used: JAXSR's information criteria use the
+    nominal sample size ``n`` (see :func:`validate_sample_weight`).  A value
+    much smaller than ``n`` is a warning sign that most of the data is being
+    down-weighted to irrelevance, so AIC/BIC comparisons rest on far less
+    information than ``n`` suggests.
+
+    Parameters
+    ----------
+    sample_weight : jnp.ndarray or None
+        Weights of shape ``(n_samples,)``.  ``None`` returns ``n_samples``.
+    n_samples : int
+        Number of samples.
+
+    Returns
+    -------
+    float
+        Effective sample size, between 1 and ``n_samples``.
+    """
+    if sample_weight is None:
+        return float(n_samples)
+    total = float(jnp.sum(sample_weight))
+    sum_sq = float(jnp.sum(sample_weight**2))
+    if sum_sq <= 0:
+        return 0.0
+    return total**2 / sum_sq
+
+
+# =============================================================================
 # Validation Utilities
 # =============================================================================
 

--- a/tests/test_sample_weight.py
+++ b/tests/test_sample_weight.py
@@ -306,7 +306,15 @@ class TestMetricFunctions:
 
 
 class TestFittingPrimitives:
-    """The low-level solvers."""
+    """The low-level solvers.
+
+    These compare a JAX solve against a float64 NumPy reference.  Under JAX's
+    default float32 that is a cross-precision comparison, so the tolerances
+    carry an ``atol``: a coefficient that lands near zero has a large relative
+    error for a tiny absolute one, and judging it on ``rtol`` alone makes the
+    test fail on rounding rather than on the identity being checked.  The
+    NumPy backend runs the same assertions in float64, where they are tight.
+    """
 
     def test_fit_ols_matches_normal_equations(self):
         rng = np.random.default_rng(5)
@@ -318,11 +326,11 @@ class TestFittingPrimitives:
 
         W = np.diag(w)
         expected = np.linalg.solve(Phi.T @ W @ Phi, Phi.T @ W @ y)
-        np.testing.assert_allclose(np.asarray(coeffs), expected, rtol=1e-5)
+        np.testing.assert_allclose(np.asarray(coeffs), expected, rtol=1e-4, atol=1e-6)
 
         w_norm = w * (len(w) / w.sum())
         resid = y - Phi @ np.asarray(coeffs)
-        assert mse == pytest.approx(float(np.sum(w_norm * resid**2) / len(y)), rel=1e-5)
+        assert mse == pytest.approx(float(np.sum(w_norm * resid**2) / len(y)), rel=1e-4)
 
     def test_fit_ridge_is_weighted(self):
         rng = np.random.default_rng(6)
@@ -335,7 +343,7 @@ class TestFittingPrimitives:
 
         W = np.diag(w_norm)
         expected = np.linalg.solve(Phi.T @ W @ Phi + 0.5 * np.eye(3), Phi.T @ W @ y)
-        np.testing.assert_allclose(np.asarray(coeffs), expected, rtol=1e-5)
+        np.testing.assert_allclose(np.asarray(coeffs), expected, rtol=1e-4, atol=1e-6)
 
     def test_unweighted_calls_are_unchanged(self):
         Phi = jnp.column_stack([jnp.ones(4), jnp.array([1.0, 2.0, 3.0, 4.0])])

--- a/tests/test_sample_weight.py
+++ b/tests/test_sample_weight.py
@@ -1,0 +1,618 @@
+"""Tests for ``sample_weight`` support across the library.
+
+The invariants exercised here are the ones that make weights trustworthy:
+uniform weights change nothing, the overall scale of the weights changes
+nothing, a zero weight is equivalent to deleting the row from the fit, and
+every derived quantity (MSE, information criteria, R², intervals, ANOVA)
+is computed from the same weighted objective the coefficients came from.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jaxsr import (
+    BasisLibrary,
+    Constraints,
+    MultiOutputSymbolicRegressor,
+    SymbolicRegressor,
+    cross_validate,
+    fit_symbolic,
+)
+from jaxsr.constraints import fit_constrained_ols
+from jaxsr.metrics import (
+    compute_information_criterion,
+    compute_mae,
+    compute_mse,
+    compute_r2,
+    compute_rmse,
+)
+from jaxsr.selection import (
+    exhaustive_search,
+    fit_ols,
+    fit_ridge,
+    greedy_backward_elimination,
+    greedy_forward_selection,
+    lasso_path_selection,
+    select_features,
+)
+from jaxsr.uncertainty import (
+    anova,
+    bootstrap_coefficients,
+    bootstrap_model_selection,
+    coefficient_intervals,
+    conformal_predict_jackknife_plus,
+)
+from jaxsr.utils import effective_sample_size, validate_sample_weight, whiten
+
+
+def _library():
+    """Small polynomial library in one variable."""
+    return (
+        BasisLibrary(n_features=1, feature_names=["x"])
+        .add_constant()
+        .add_linear()
+        .add_polynomials(max_degree=3)
+    )
+
+
+def _corrupted_half():
+    """The reproducer from the issue: half the data is corrupt and down-weighted."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(200, 1))
+    y = 3 * X[:, 0] + 0.1 * rng.normal(size=200)
+    y[:100] += 50  # corrupt the first half
+    w = np.ones(200)
+    w[:100] = 1e-6  # ...and down-weight exactly that half
+    return jnp.array(X), jnp.array(y), jnp.array(w)
+
+
+class TestValidateSampleWeight:
+    """Tests for weight validation and normalisation."""
+
+    def test_none_passes_through(self):
+        assert validate_sample_weight(None, 10) is None
+
+    def test_normalised_to_sum_n(self):
+        w = validate_sample_weight(np.array([1e-3, 1e-3, 2e-3, 2e-3]), 4)
+        assert float(jnp.sum(w)) == pytest.approx(4.0)
+        # ratios preserved
+        assert float(w[2] / w[0]) == pytest.approx(2.0)
+
+    def test_idempotent(self):
+        w1 = validate_sample_weight(np.array([1.0, 3.0, 4.0]), 3)
+        w2 = validate_sample_weight(w1, 3)
+        np.testing.assert_allclose(np.asarray(w1), np.asarray(w2))
+
+    def test_wrong_length_raises(self):
+        with pytest.raises(ValueError, match="entries but there are"):
+            validate_sample_weight(np.ones(5), 4)
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            validate_sample_weight(np.array([1.0, -1.0]), 2)
+
+    def test_nonfinite_raises(self):
+        with pytest.raises(ValueError, match="finite"):
+            validate_sample_weight(np.array([1.0, np.nan]), 2)
+
+    def test_all_zero_raises(self):
+        with pytest.raises(ValueError, match="positive sum"):
+            validate_sample_weight(np.zeros(4), 4)
+
+    def test_whiten_matches_manual(self):
+        w = jnp.array([4.0, 1.0, 0.0])
+        Phi = jnp.arange(6.0).reshape(3, 2)
+        np.testing.assert_allclose(
+            np.asarray(whiten(Phi, w)), np.asarray(Phi) * np.sqrt([[4.0], [1.0], [0.0]])
+        )
+
+    def test_effective_sample_size(self):
+        assert effective_sample_size(None, 7) == 7.0
+        assert effective_sample_size(jnp.ones(7), 7) == pytest.approx(7.0)
+        # half the rows carrying essentially no weight halves the ESS
+        w = validate_sample_weight(np.r_[np.full(50, 1e-9), np.ones(50)], 100)
+        assert effective_sample_size(w, 100) == pytest.approx(50.0, rel=1e-3)
+
+
+class TestIssueReproducer:
+    """The exact scenario reported: weights must change the answer."""
+
+    def test_weighted_fit_recovers_clean_model(self):
+        X, y, w = _corrupted_half()
+        library = _library()
+
+        unweighted = SymbolicRegressor(basis_library=library, max_terms=2).fit(X, y)
+        weighted = SymbolicRegressor(basis_library=library, max_terms=2).fit(X, y, sample_weight=w)
+        clean = SymbolicRegressor(basis_library=library, max_terms=2).fit(X[100:], y[100:])
+
+        # The bug was that these two were identical.
+        assert weighted.expression_ != unweighted.expression_
+        # The weighted fit agrees with a fit on the uncorrupted half alone.
+        assert weighted.selected_features_ == clean.selected_features_
+        np.testing.assert_allclose(
+            np.asarray(weighted.coefficients_),
+            np.asarray(clean.coefficients_),
+            rtol=1e-3,
+        )
+
+    def test_effective_sample_size_reports_the_loss(self):
+        X, y, w = _corrupted_half()
+        model = SymbolicRegressor(basis_library=_library(), max_terms=2).fit(X, y, sample_weight=w)
+        assert model.effective_sample_size_ == pytest.approx(100.0, rel=1e-3)
+        # ...but n itself is unchanged, which is what the criteria use.
+        assert model._result.n_samples == 200
+
+
+class TestInvariants:
+    """Properties that must hold for any weighting scheme."""
+
+    @pytest.fixture
+    def data(self):
+        rng = np.random.default_rng(3)
+        X = rng.normal(size=(60, 1))
+        y = 2.0 * X[:, 0] + 0.5 + 0.05 * rng.normal(size=60)
+        return jnp.array(X), jnp.array(y)
+
+    @pytest.mark.parametrize(
+        "strategy", ["greedy_forward", "greedy_backward", "exhaustive", "lasso_path"]
+    )
+    def test_uniform_weights_match_unweighted(self, data, strategy):
+        X, y = data
+        library = _library()
+        kw = {"basis_library": library, "max_terms": 3, "strategy": strategy}
+
+        plain = SymbolicRegressor(**kw).fit(X, y)
+        uniform = SymbolicRegressor(**kw).fit(X, y, sample_weight=jnp.ones(len(y)))
+
+        assert uniform.selected_features_ == plain.selected_features_
+        np.testing.assert_allclose(
+            np.asarray(uniform.coefficients_), np.asarray(plain.coefficients_), rtol=1e-6
+        )
+        assert uniform.metrics_["bic"] == pytest.approx(plain.metrics_["bic"], rel=1e-9)
+
+    def test_scale_invariance(self, data):
+        """Only weight ratios matter -- w and 1000*w must agree exactly."""
+        X, y = data
+        w = jnp.array(np.linspace(0.5, 2.0, len(y)))
+        library = _library()
+
+        small = SymbolicRegressor(basis_library=library, max_terms=3).fit(X, y, sample_weight=w)
+        large = SymbolicRegressor(basis_library=library, max_terms=3).fit(
+            X, y, sample_weight=1000.0 * w
+        )
+
+        assert small.selected_features_ == large.selected_features_
+        # Only float32 rounding of the rescaling separates the two.
+        np.testing.assert_allclose(
+            np.asarray(small.coefficients_), np.asarray(large.coefficients_), rtol=1e-5
+        )
+        assert small.metrics_["mse"] == pytest.approx(large.metrics_["mse"], rel=1e-5)
+        assert small.metrics_["aic"] == pytest.approx(large.metrics_["aic"], rel=1e-5)
+
+    def test_zero_weight_equals_dropping_the_row(self, data):
+        """A weight of 0 removes a row from the fit (though not from n)."""
+        X, y = data
+        w = np.ones(len(y))
+        w[:10] = 0.0
+        library = _library()
+
+        zeroed = SymbolicRegressor(basis_library=library, max_terms=2).fit(
+            X, y, sample_weight=jnp.array(w)
+        )
+        dropped = SymbolicRegressor(basis_library=library, max_terms=2).fit(X[10:], y[10:])
+
+        assert zeroed.selected_features_ == dropped.selected_features_
+        np.testing.assert_allclose(
+            np.asarray(zeroed.coefficients_), np.asarray(dropped.coefficients_), rtol=1e-5
+        )
+
+    def test_integer_weights_match_row_duplication_in_coefficients_only(self, data):
+        """Doubling a weight fits like duplicating the row -- but n must not move."""
+        X, y = data
+        w = np.ones(len(y))
+        w[:20] = 2.0
+        library = _library()
+
+        weighted = SymbolicRegressor(basis_library=library, max_terms=2).fit(
+            X, y, sample_weight=jnp.array(w)
+        )
+        duplicated = SymbolicRegressor(basis_library=library, max_terms=2).fit(
+            jnp.concatenate([X, X[:20]]), jnp.concatenate([y, y[:20]])
+        )
+
+        np.testing.assert_allclose(
+            np.asarray(weighted.coefficients_), np.asarray(duplicated.coefficients_), rtol=1e-5
+        )
+        # ...and this is exactly why duplication is not a valid emulation:
+        assert weighted._result.n_samples == len(y)
+        assert duplicated._result.n_samples == len(y) + 20
+        assert weighted.metrics_["bic"] != pytest.approx(duplicated.metrics_["bic"])
+
+
+class TestReportedQuantities:
+    """MSE, information criteria and R² must come from the weighted objective."""
+
+    @pytest.fixture
+    def fitted(self):
+        X, y, w = _corrupted_half()
+        model = SymbolicRegressor(basis_library=_library(), max_terms=2).fit(X, y, sample_weight=w)
+        return model, X, y, w
+
+    def test_mse_is_the_weighted_mse(self, fitted):
+        model, X, y, w = fitted
+        expected = compute_mse(y, model.predict(X), w)
+        assert model.metrics_["mse"] == pytest.approx(expected, rel=1e-6)
+
+    def test_information_criteria_use_weighted_mse_and_nominal_n(self, fitted):
+        model, X, y, w = fitted
+        k = len(model.coefficients_)
+        for criterion in ("aic", "bic", "aicc"):
+            expected = compute_information_criterion(len(y), k, model.metrics_["mse"], criterion)
+            assert model.metrics_[criterion] == pytest.approx(expected, rel=1e-9)
+
+    def test_r2_is_weighted(self, fitted):
+        model, X, y, w = fitted
+        expected = compute_r2(y, model.predict(X), w)
+        assert model.metrics_["r2"] == pytest.approx(expected, rel=1e-6)
+        # The unweighted R2 on corrupted data is far worse; weighting must not
+        # silently report that number.
+        assert model.metrics_["r2"] > compute_r2(y, model.predict(X))
+
+    def test_score_accepts_its_own_weights(self, fitted):
+        model, X, y, w = fitted
+        assert model.score(X, y, sample_weight=w) == pytest.approx(
+            compute_r2(y, model.predict(X), w), rel=1e-6
+        )
+        assert model.score(X, y) != pytest.approx(model.score(X, y, sample_weight=w))
+
+    def test_sample_weight_property_is_normalised(self, fitted):
+        model, _X, y, _w = fitted
+        assert float(jnp.sum(model.sample_weight_)) == pytest.approx(len(y))
+
+    def test_unweighted_model_reports_none(self):
+        X, y, _w = _corrupted_half()
+        model = SymbolicRegressor(basis_library=_library(), max_terms=2).fit(X, y)
+        assert model.sample_weight_ is None
+        assert model.effective_sample_size_ == pytest.approx(len(y))
+
+
+class TestMetricFunctions:
+    """Weighted metrics against hand-computed values."""
+
+    def test_weighted_mse_and_mae(self):
+        y = jnp.array([0.0, 0.0, 0.0, 0.0])
+        y_pred = jnp.array([1.0, 1.0, 3.0, 3.0])
+        w = jnp.array([3.0, 3.0, 1.0, 1.0])
+        # normalised weights are [1.5, 1.5, 0.5, 0.5]
+        assert compute_mse(y, y_pred, w) == pytest.approx((1.5 + 1.5 + 4.5 + 4.5) / 4)
+        assert compute_rmse(y, y_pred, w) == pytest.approx(np.sqrt(3.0))
+        assert compute_mae(y, y_pred, w) == pytest.approx((1.5 + 1.5 + 1.5 + 1.5) / 4)
+
+    def test_weighted_r2_uses_weighted_mean(self):
+        y = jnp.array([0.0, 2.0, 100.0, 200.0])
+        y_pred = jnp.array([0.0, 2.0, 0.0, 0.0])
+        # With effectively all the weight on the first two points -- which the
+        # model fits exactly -- R2 is 1 even though it misses the other two by
+        # a mile.  The total sum of squares is taken about the weighted mean
+        # (1.0 here), not the plain mean (75.5).
+        w = jnp.array([1.0, 1.0, 1e-12, 1e-12])
+        assert compute_r2(y, y_pred, w) == pytest.approx(1.0, abs=1e-6)
+        assert compute_r2(y, y_pred) < 0.1
+
+    def test_invalid_weight_raises(self):
+        with pytest.raises(ValueError):
+            compute_mse(jnp.zeros(3), jnp.zeros(3), jnp.array([1.0, -1.0, 1.0]))
+
+
+class TestFittingPrimitives:
+    """The low-level solvers."""
+
+    def test_fit_ols_matches_normal_equations(self):
+        rng = np.random.default_rng(5)
+        Phi = rng.normal(size=(30, 3))
+        y = rng.normal(size=30)
+        w = np.abs(rng.normal(size=30)) + 0.1
+
+        coeffs, mse = fit_ols(jnp.array(Phi), jnp.array(y), sample_weight=jnp.array(w))
+
+        W = np.diag(w)
+        expected = np.linalg.solve(Phi.T @ W @ Phi, Phi.T @ W @ y)
+        np.testing.assert_allclose(np.asarray(coeffs), expected, rtol=1e-5)
+
+        w_norm = w * (len(w) / w.sum())
+        resid = y - Phi @ np.asarray(coeffs)
+        assert mse == pytest.approx(float(np.sum(w_norm * resid**2) / len(y)), rel=1e-5)
+
+    def test_fit_ridge_is_weighted(self):
+        rng = np.random.default_rng(6)
+        Phi = rng.normal(size=(30, 3))
+        y = rng.normal(size=30)
+        w = np.abs(rng.normal(size=30)) + 0.1
+        w_norm = w * (len(w) / w.sum())
+
+        coeffs, _ = fit_ridge(jnp.array(Phi), jnp.array(y), 0.5, sample_weight=jnp.array(w))
+
+        W = np.diag(w_norm)
+        expected = np.linalg.solve(Phi.T @ W @ Phi + 0.5 * np.eye(3), Phi.T @ W @ y)
+        np.testing.assert_allclose(np.asarray(coeffs), expected, rtol=1e-5)
+
+    def test_unweighted_calls_are_unchanged(self):
+        Phi = jnp.column_stack([jnp.ones(4), jnp.array([1.0, 2.0, 3.0, 4.0])])
+        y = jnp.array([3.0, 5.0, 7.0, 9.0])
+        coeffs, mse = fit_ols(Phi, y)
+        np.testing.assert_allclose(np.asarray(coeffs), [1.0, 2.0], atol=1e-5)
+        assert mse < 1e-10
+
+
+class TestSelectionStrategies:
+    """Weights must steer term selection, not only the final coefficients."""
+
+    @pytest.fixture
+    def problem(self):
+        X, y, w = _corrupted_half()
+        library = _library()
+        Phi = library.evaluate(X)
+        return Phi, y, w, library
+
+    @pytest.mark.parametrize(
+        "func",
+        [
+            greedy_forward_selection,
+            greedy_backward_elimination,
+            exhaustive_search,
+            lasso_path_selection,
+        ],
+    )
+    def test_strategy_accepts_weights(self, problem, func):
+        Phi, y, w, library = problem
+        path = func(
+            Phi,
+            y,
+            library.names,
+            library.complexities,
+            max_terms=2,
+            sample_weight=w,
+        )
+        # The clean signal is y = 3x; the corrupted, unweighted fit picks up a
+        # large constant instead.
+        assert "x" in path.best.selected_names
+
+    def test_select_features_forwards_weights(self, problem):
+        Phi, y, w, library = problem
+        weighted = select_features(
+            Phi, y, library.names, library.complexities, max_terms=2, sample_weight=w
+        )
+        plain = select_features(Phi, y, library.names, library.complexities, max_terms=2)
+        assert weighted.best.selected_names != plain.best.selected_names
+
+
+class TestConstraints:
+    """Constrained refits must honour the weights too."""
+
+    def test_constrained_refit_is_weighted(self):
+        X, y, w = _corrupted_half()
+        constraints = Constraints().add_sign_constraint("x", "positive")
+
+        model = SymbolicRegressor(
+            basis_library=_library(), max_terms=2, constraints=constraints
+        ).fit(X, y, sample_weight=w)
+
+        assert "x" in model.selected_features_
+        idx = model.selected_features_.index("x")
+        assert float(model.coefficients_[idx]) == pytest.approx(3.0, rel=0.05)
+
+    def test_fit_constrained_ols_weighted_matches_wls(self):
+        rng = np.random.default_rng(9)
+        Phi = rng.normal(size=(40, 2))
+        y = rng.normal(size=40)
+        w = np.abs(rng.normal(size=40)) + 0.1
+
+        coeffs, mse = fit_constrained_ols(
+            Phi=jnp.array(Phi),
+            y=jnp.array(y),
+            constraints=Constraints(),  # no constraints -> plain WLS fast path
+            basis_names=["a", "b"],
+            feature_names=["x"],
+            X=jnp.array(rng.normal(size=(40, 1))),
+            sample_weight=jnp.array(w),
+        )
+
+        W = np.diag(w)
+        expected = np.linalg.solve(Phi.T @ W @ Phi, Phi.T @ W @ y)
+        np.testing.assert_allclose(np.asarray(coeffs), expected, rtol=1e-4)
+        assert mse > 0
+
+
+class TestUncertainty:
+    """Intervals, bootstrap and ANOVA under weights."""
+
+    @pytest.fixture
+    def fitted(self):
+        X, y, w = _corrupted_half()
+        model = SymbolicRegressor(basis_library=_library(), max_terms=2).fit(X, y, sample_weight=w)
+        return model, X, y, w
+
+    def test_coefficient_intervals_are_weighted(self, fitted):
+        model, _X, _y, _w = fitted
+        intervals = model.coefficient_intervals()
+        est, lo, hi, se = intervals["x"]
+        assert lo < est < hi
+        # The corrupted rows carry ~no weight, so the SE reflects the clean half.
+        assert se < 0.05
+
+    def test_coefficient_intervals_function_respects_weights(self, fitted):
+        model, X, y, w = fitted
+        Phi = model.basis_library.evaluate_subset(X, model.selected_indices_)
+        weighted = coefficient_intervals(
+            Phi, y, model.coefficients_, model.selected_features_, sample_weight=w
+        )
+        unweighted = coefficient_intervals(Phi, y, model.coefficients_, model.selected_features_)
+        assert weighted["x"][3] < unweighted["x"][3]
+
+    def test_sigma_reflects_clean_rows(self, fitted):
+        model, _X, _y, _w = fitted
+        # noise sigma of the clean half is 0.1
+        assert model.sigma_ == pytest.approx(0.1, rel=0.3)
+
+    def test_prediction_interval_is_finite_and_tight(self, fitted):
+        model, _X, _y, _w = fitted
+        X_new = jnp.array([[0.0], [1.0]])
+        y_pred, lo, hi = model.predict_interval(X_new)
+        assert bool(jnp.all(jnp.isfinite(lo))) and bool(jnp.all(jnp.isfinite(hi)))
+        assert bool(jnp.all(hi - lo < 2.0))
+
+    def test_bootstrap_coefficients_uses_weights(self, fitted):
+        model, _X, _y, _w = fitted
+        boot = bootstrap_coefficients(model, n_bootstrap=100, seed=0)
+        i = boot["names"].index("x")
+        assert float(boot["mean"][i]) == pytest.approx(3.0, rel=0.05)
+        assert float(boot["std"][i]) < 0.05
+
+    def test_bootstrap_model_selection_inherits_weights(self, fitted):
+        model, X, y, _w = fitted
+        result = bootstrap_model_selection(model, X, y, n_bootstrap=5, seed=0)
+        assert result["feature_frequencies"].get("x", 0.0) > 0.5
+
+    def test_jackknife_conformal_runs_weighted(self, fitted):
+        model, _X, _y, _w = fitted
+        result = conformal_predict_jackknife_plus(model, jnp.array([[0.5]]), alpha=0.1)
+        assert bool(jnp.all(jnp.isfinite(result["lower"])))
+        assert float(result["upper"][0] - result["lower"][0]) < 2.0
+
+    def test_anova_sums_of_squares_are_weighted(self, fitted):
+        model, _X, _y, _w = fitted
+        table = anova(model)
+        rows = {r.source: r for r in table.rows}
+        assert rows["Residual"].sum_sq == pytest.approx(
+            model.metrics_["mse"] * model._result.n_samples, rel=1e-4
+        )
+        assert rows["Total"].sum_sq == pytest.approx(
+            rows["Model"].sum_sq + rows["Residual"].sum_sq, rel=1e-6
+        )
+
+
+class TestAcquisition:
+    """Active learning must score candidates against the weighted posterior."""
+
+    def test_uncertainty_reflects_weights(self):
+        """A region whose data was down-weighted must still look uncertain."""
+        from jaxsr.acquisition import PredictionVariance
+
+        rng = np.random.default_rng(17)
+        X = jnp.array(np.sort(rng.uniform(-3, 3, size=(60, 1)), axis=0))
+        x = np.asarray(X)[:, 0]
+        # An intercept as well as a slope, so the design has a centre and the
+        # leverage is not symmetric about x = 0.
+        y = jnp.array(5.0 + 2.0 * x + 0.1 * rng.normal(size=60))
+
+        library = BasisLibrary(n_features=1, feature_names=["x"]).add_constant().add_linear()
+        # Trust only the left half of the domain.
+        w = np.where(x < 0, 1.0, 1e-6)
+
+        weighted = SymbolicRegressor(basis_library=library, max_terms=2).fit(
+            X, y, sample_weight=jnp.array(w)
+        )
+        plain = SymbolicRegressor(basis_library=library, max_terms=2).fit(X, y)
+
+        candidates = jnp.array([[-2.0], [2.0]])
+        acq = PredictionVariance()
+        w_scores = np.asarray(acq.score(candidates, weighted))
+        p_scores = np.asarray(acq.score(candidates, plain))
+
+        # Unweighted, the two ends of the domain look comparably informed.
+        # Weighted, the untrusted right end is far more uncertain, which is
+        # where the next experiment should go.
+        assert w_scores[1] / w_scores[0] > 5 * (p_scores[1] / p_scores[0])
+
+    def test_kriging_believer_batch_runs_weighted(self):
+        from jaxsr.acquisition import ActiveLearner, PredictionVariance
+
+        X, y, w = _corrupted_half()
+        model = SymbolicRegressor(basis_library=_library(), max_terms=2).fit(X, y, sample_weight=w)
+        learner = ActiveLearner(model, bounds=[(-3.0, 3.0)], acquisition=PredictionVariance())
+        result = learner.suggest(n_points=3, batch_strategy="kriging_believer")
+
+        assert result.points.shape == (3, 1)
+        # The fantasy updates must leave the model exactly as they found it.
+        assert len(model.sample_weight_) == len(y)
+        assert model._X_train.shape[0] == len(y)
+
+
+class TestCrossValidation:
+    """Weights follow their rows into the folds."""
+
+    def test_cross_validate_with_weights(self):
+        X, y, w = _corrupted_half()
+        model = SymbolicRegressor(basis_library=_library(), max_terms=2)
+        weighted = cross_validate(model, X, y, cv=3, sample_weight=w, random_state=0)
+        plain = cross_validate(model, X, y, cv=3, random_state=0)
+        # Down-weighting the corrupted half makes the folds far more predictable.
+        assert weighted["mean_test_score"] > plain["mean_test_score"]
+
+
+class TestOtherEntryPoints:
+    """The remaining public surfaces that take data."""
+
+    def test_fit_symbolic_forwards_weights(self):
+        X, y, w = _corrupted_half()
+        model = fit_symbolic(X, y, max_terms=2, include_transcendental=False, sample_weight=w)
+        assert "x0" in model.selected_features_
+
+    def test_multioutput_shares_weights(self):
+        X, y, w = _corrupted_half()
+        Y = jnp.column_stack([y, y])
+        mo = MultiOutputSymbolicRegressor(
+            estimator=SymbolicRegressor(basis_library=_library(), max_terms=2)
+        ).fit(X, Y, sample_weight=w)
+        for est in mo.estimators_:
+            assert "x" in est.selected_features_
+
+    def test_update_keeps_weights(self):
+        X, y, w = _corrupted_half()
+        model = SymbolicRegressor(basis_library=_library(), max_terms=2).fit(X, y, sample_weight=w)
+        model.update(jnp.array([[0.0]]), jnp.array([0.0]), refit=False)
+        assert model.sample_weight_ is not None
+        assert len(model.sample_weight_) == 201
+        # the appended point enters at unit weight, the corrupt rows stay tiny
+        assert float(model.sample_weight_[-1]) > float(model.sample_weight_[0]) * 100
+
+    def test_update_with_explicit_new_weights(self):
+        rng = np.random.default_rng(11)
+        X = jnp.array(rng.normal(size=(30, 1)))
+        y = jnp.array(2.0 * np.asarray(X)[:, 0])
+        model = SymbolicRegressor(basis_library=_library(), max_terms=2).fit(X, y)
+        model.update(
+            jnp.array([[5.0]]),
+            jnp.array([100.0]),
+            refit=False,
+            sample_weight_new=jnp.array([0.0]),
+        )
+        # A zero-weight outlier must not move the fit.
+        assert float(model.predict(jnp.array([[1.0]]))[0]) == pytest.approx(2.0, rel=1e-3)
+
+
+class TestParametricBasis:
+    """Parametric columns are rebuilt from X and must be whitened to match."""
+
+    def test_parametric_fit_respects_weights(self):
+        rng = np.random.default_rng(13)
+        X = jnp.array(rng.uniform(0.5, 3.0, size=(60, 1)))
+        x = np.asarray(X)[:, 0]
+        y = np.exp(-2.0 * x)
+        y[:30] += 5.0  # corrupt half
+        w = np.ones(60)
+        w[:30] = 1e-8
+
+        library = BasisLibrary(n_features=1, feature_names=["x"]).add_constant()
+        library.add_parametric(
+            name="exp(-a*x)",
+            func=lambda X, a: jnp.exp(-a * X[:, 0]),
+            param_bounds={"a": (0.1, 10.0)},
+        )
+
+        model = SymbolicRegressor(basis_library=library, max_terms=2).fit(
+            X, jnp.array(y), sample_weight=jnp.array(w)
+        )
+        # The optimised decay constant should come from the clean half.
+        assert model.metrics_["mse"] < 1e-3


### PR DESCRIPTION
Closes #19.

`SymbolicRegressor.fit()` accepted `sample_weight`, documented it as "not yet implemented", and dropped it on the floor. A user passing measurement variances got a plausible answer computed from the assumption they believed they had overridden.

The reproducer from the issue now gives:

```
no weights  : y = 25.28 + 2.074*x^3
with weights: y = 2.989*x        # identical to fitting the clean half alone
```

## Mechanism

WLS on `(Phi, y)` is OLS on `(sqrt(w)·Phi, sqrt(w)·y)`, so the weights are applied by whitening at each entry point rather than by growing a parallel weighted code path. The Gram-matrix fast paths, the LASSO screening, the SVD interval machinery and the closed-form MSE all stay exact and untouched.

Two places deliberately keep the **raw** matrix:

- **constraint evaluation** — a monotonicity or convexity constraint is a property of the fitted function over the design space, not of how much a given row was trusted, so a down-weighted row still has to obey it;
- **`Phi_new` in prediction intervals** — so the interval is for a new observation of unit weight (one as precise as an average training point).

## Where weights now apply

Everything the issue listed, plus a few things that would otherwise have been inconsistent in a way that is hard to see:

- all four selection strategies, so weights steer *which terms are chosen*, not only their coefficients
- the reported MSE, R², and the AIC/BIC/AICc computed from them
- constraint refitting (`fit_constrained_ols`), negligible-term pruning, and the profile-likelihood optimisation of parametric basis parameters
- `sigma_`, `covariance_matrix_`, `coefficient_intervals()`, `predict_interval()`, `confidence_band()`, `anova()`, the bootstrap functions, `cross_validate()`, jackknife+ conformal prediction
- the active-learning posterior in `acquisition.py`, which was scoring candidates against the unweighted `(PhiᵀPhi)⁻¹` — it would have proposed the next experiment as if the down-weighted rows had been fully informative. The kriging-believer batch path also grew `_X_train` without the matching weights.

The parametric case is a good illustration of why partial coverage is not enough: unweighted, the test fixture collapses to a constant; weighted, it recovers `exp(-2*x)`.

## Effective-sample-size policy

Weights are normalised to average 1, so only their ratios matter and the fit is invariant to their overall scale — `w`, `2*w` and `w/1000` give the same model, MSE and criteria. The `n` used by the information criteria stays the **nominal** sample count: weighting describes how much each measurement is trusted, it does not create or destroy measurements. That is precisely why duplicating rows is not an equivalent trick — it inflates `n` and shifts every criterion.

New `SymbolicRegressor.effective_sample_size_` reports the Kish ESS as a diagnostic for when the nominal `n` overstates the evidence (100.0 for the 200-point reproducer). `sample_weight_` exposes the normalised weights.

Invalid weights (wrong length, negative, non-finite, all-zero) now raise `ValueError` rather than being ignored.

## API surface

`sample_weight` was also added to `fit_symbolic()`, `MultiOutputSymbolicRegressor.fit()`, `SymbolicRegressor.score()`, `fit_ols()`, `fit_ridge()`, `select_features()` and the four strategy functions, `cross_validate()`, `compute_mse/rmse/mae/r2/adjusted_r2/mape/all_metrics()`, `compute_cv_score()`, `compute_loo_mse()`, `compute_press()`, and `bootstrap_model_selection()`. `SymbolicRegressor.update()` gained `sample_weight_new`.

## Deliberately not weighted

- `conformal_predict_split()` — its coverage comes from exchangeability of the user-supplied calibration residuals, not from the fit. Documented, with a pointer to `method="jackknife+"` for a weight-aware interval.
- `SymbolicClassifier` — it never accepted the argument, so there is no silent-ignore bug there.
- `max_error` in `compute_all_metrics()` — a maximum has no weighted analogue; it is now taken over the rows with non-zero weight instead of over rows that carry none.

## Docs

New `docs/guides/sample-weights.md` and the matching skill guide (`src/jaxsr/skill/` re-synced from `.claude/skills/jaxsr/`), covering weight semantics, the effective-sample-size policy, recipes for variance-derived and replicate weights, and what is left unweighted. Includes the smooth-taper recipe `w = y_x² / (y_x² + eps²)` for the superposition case in #14, in place of a hard `|y_x|` threshold.

## Verification

- 674 tests pass on JAX and on the NumPy/Pyodide backend (`scripts/test_under_numpy.py`)
- `black --check` and `ruff check` clean
- coverage 63.8% (threshold 60%)
- 53 new tests in `tests/test_sample_weight.py`, built around the invariants that make weights trustworthy: uniform weights change nothing, scale invariance, a zero weight equals dropping the row, and integer weights match row duplication *in the coefficients* while `n` correctly does not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JigoMqmadVXVs7ALgnLnvG

---
_Generated by [Claude Code](https://claude.ai/code/session_01JigoMqmadVXVs7ALgnLnvG)_